### PR TITLE
Expand ~ in contrib.files.exists()

### DIFF
--- a/fabric/contrib/files.py
+++ b/fabric/contrib/files.py
@@ -25,7 +25,7 @@ def exists(path, use_sudo=False, verbose=False):
     behavior.
     """
     func = use_sudo and sudo or run
-    cmd = 'test -e "%s"' % path
+    cmd = 'test -e "$(echo %s)"' % path
     # If verbose, run normally
     if verbose:
         with settings(warn_only=True):


### PR DESCRIPTION
It would be pretty handy to be able to use ~ in contrib.files.exists(), the attached commit permit me to use it.
I'm sorry but i can't run the tests because fudge is not available in debian so lot of them fails. Please review. Thanks!
