### PR TITLE
Include traceback when wrapping import errors

### DIFF
--- a/fabric/contrib/files.py
+++ b/fabric/contrib/files.py
@@ -101,8 +101,10 @@ def upload_template(filename, destination, context=None, use_jinja=False,
             from jinja2 import Environment, FileSystemLoader
             jenv = Environment(loader=FileSystemLoader(template_dir or '.'))
             text = jenv.get_template(filename).render(**context or {})
-        except ImportError, e:
-            abort("tried to use Jinja2 but was unable to import: %s" % e)
+        except ImportError:
+            import traceback
+            tb = traceback.format_exc()
+            abort(tb + "\nCould not import Jinja2 (see traceback above)")
     else:
         with open(filename) as inputfile:
             text = inputfile.read()

--- a/fabric/network.py
+++ b/fabric/network.py
@@ -20,11 +20,13 @@ try:
     warnings.simplefilter('ignore', DeprecationWarning)
     import paramiko as ssh
 except ImportError, e:
-    print >> sys.stderr, """There was a problem importing our SSH library. Specifically:
-
-    %s
-
-Please make sure all dependencies are installed and importable.""" % e
+    import traceback
+    import textwrap
+    traceback.print_exc()
+    print >> sys.stderr, textwrap.dedent("""
+        There was a problem importing our SSH library (see traceback above).
+        Please make sure all dependencies are installed and importable.
+    """).rstrip()
     sys.exit(1)
 
 

--- a/fabric/tasks.py
+++ b/fabric/tasks.py
@@ -204,11 +204,18 @@ def execute(task, *args, **kwargs):
                     # if it can't.
                     try:
                         import multiprocessing
-                    except ImportError, e:
-                        msg = "At least one task needs to be run in parallel, but the\nmultiprocessing module cannot be imported:"
-                        msg += "\n\n\t%s\n\n" % e
-                        msg += "Please make sure the module is installed or that the above ImportError is\nfixed."
-                        abort(msg)
+                    except ImportError:
+                        import traceback
+                        import textwrap
+                        tb = traceback.format_exc()
+                        abort(tb + textwrap.dedent("""
+                            At least one task needs to be run in parallel, but
+                            the multiprocessing module cannot be imported (see
+                            traceback, above).
+
+                            Please make sure the module is installed or that
+                            the above ImportError is fixed.
+                        """).rstrip())
 
                     # Wrap in another callable that nukes the child's cached
                     # connection object, if needed, to prevent shared-socket


### PR DESCRIPTION
Without the complete tracebacks it's fairly frustrating to try and track down the import errors.
