### PR TITLE
Modified @hosts and @roles to allow callable args

### DIFF
--- a/fabric/decorators.py
+++ b/fabric/decorators.py
@@ -48,8 +48,9 @@ def hosts(*host_list):
             pass
 
     `~fabric.decorators.hosts` may be invoked with either an argument list
-    (``@hosts('host1')``, ``@hosts('host1', 'host2')``) or a single, iterable
-    argument (``@hosts(['host1', 'host2'])``).
+    (``@hosts('host1')``, ``@hosts('host1', 'host2')``), a single, iterable
+    argument (``@hosts(['host1', 'host2'])``), or a callable that returns
+    a list of hosts (``@hosts(some_func)``).
 
     Note that this decorator actually just sets the function's ``.hosts``
     attribute, which is then read prior to executing the function.
@@ -67,7 +68,7 @@ def hosts(*host_list):
         # Allow for single iterable argument as well as *args
         if len(_hosts) == 1 and not isinstance(_hosts[0], basestring):
             _hosts = _hosts[0]
-        inner_decorator.hosts = list(_hosts)
+        inner_decorator.hosts = _hosts if callable(_hosts) else list(_hosts)
         return inner_decorator
     return attach_hosts
 
@@ -91,9 +92,10 @@ def roles(*role_list):
             pass
 
     As with `~fabric.decorators.hosts`, `~fabric.decorators.roles` may be
-    invoked with either an argument list or a single, iterable argument.
-    Similarly, this decorator uses the same mechanism as
-    `~fabric.decorators.hosts` and simply sets ``<function>.roles``.
+    invoked with either an argument list, a single, iterable argument, or
+    a callable that returns a list of roles.  Similarly, this decorator
+    uses the same mechanism as `~fabric.decorators.hosts` and simply sets
+    ``<function>.roles``.
 
     .. versionchanged:: 0.9.2
         Allow a single, iterable argument to be used (same as
@@ -107,7 +109,7 @@ def roles(*role_list):
         # Allow for single iterable argument as well as *args
         if len(_roles) == 1 and not isinstance(_roles[0], basestring):
             _roles = _roles[0]
-        inner_decorator.roles = list(_roles)
+        inner_decorator.roles = _roles if callable(_roles) else list(_roles)
         return inner_decorator
     return attach_roles
 

--- a/fabric/decorators.py
+++ b/fabric/decorators.py
@@ -35,7 +35,7 @@ def task(*args, **kwargs):
     return wrapper if invoked else wrapper(func)
 
 
-def hosts(*host_list):
+def hosts(*host_list, **kwargs):
     """
     Decorator defining which host or hosts to execute the wrapped function on.
 
@@ -65,15 +65,22 @@ def hosts(*host_list):
         def inner_decorator(*args, **kwargs):
             return func(*args, **kwargs)
         _hosts = host_list
+        
+        if len(_hosts) > 0 and callable(_hosts[0]):
+            def get_hosts():
+                return _hosts[0](*_hosts[1:], **kwargs)
+            inner_decorator.hosts = get_hosts
+            return inner_decorator
+        
         # Allow for single iterable argument as well as *args
-        if len(_hosts) == 1 and not isinstance(_hosts[0], basestring):
+        elif len(_hosts) == 1 and not isinstance(_hosts[0], basestring):
             _hosts = _hosts[0]
-        inner_decorator.hosts = _hosts if callable(_hosts) else list(_hosts)
+        inner_decorator.hosts = list(_hosts)
         return inner_decorator
     return attach_hosts
 
 
-def roles(*role_list):
+def roles(*role_list, **kwargs):
     """
     Decorator defining a list of role names, used to look up host lists.
 
@@ -106,10 +113,17 @@ def roles(*role_list):
         def inner_decorator(*args, **kwargs):
             return func(*args, **kwargs)
         _roles = role_list
+        
+        if len(_roles) > 0 and callable(_roles[0]):
+            def get_roles():
+                return _roles[0](*_roles[1:], **kwargs)
+            inner_decorator.roles = get_roles
+            return inner_decorator
+        
         # Allow for single iterable argument as well as *args
         if len(_roles) == 1 and not isinstance(_roles[0], basestring):
             _roles = _roles[0]
-        inner_decorator.roles = _roles if callable(_roles) else list(_roles)
+        inner_decorator.roles = list(_roles)
         return inner_decorator
     return attach_roles
 

--- a/fabric/tasks.py
+++ b/fabric/tasks.py
@@ -55,6 +55,11 @@ class Task(object):
         # Decorator-specific hosts/roles go next
         func_hosts = getattr(self, 'hosts', [])
         func_roles = getattr(self, 'roles', [])
+        # Allow decorator hosts/roles to be callables
+        if callable(func_hosts):
+            func_hosts = func_hosts()
+        if callable(func_roles):
+            func_roles = func_roles()
         if func_hosts or func_roles:
             return merge(func_hosts, func_roles, arg_exclude_hosts, roledefs)
         # Finally, the env is checked (which might contain globally set lists

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -234,6 +234,19 @@ class TestExecute(FabricTest):
         with hide('running'):
             execute(task)
 
+    def test_should_honor_hosts_decorator_with_callable(self):
+        """
+        should honor @hosts with callable argument on passed-in task objects
+        """
+        hostlist = ['a', 'b', 'c']
+        def gen():
+            return hostlist[:]
+        @hosts(gen)
+        def task():
+            eq_(env.host_string, hostlist.pop(0))
+        with hide('running'):
+            execute(task)
+
     def test_should_honor_roles_decorator(self):
         """
         should honor @roles on passed-in task objects
@@ -247,6 +260,19 @@ class TestExecute(FabricTest):
         with settings(hide('running'), roledefs=roledefs):
             execute(task)
 
+    def test_should_honor_roles_decorator_with_callable(self):
+        """
+        should honor @roles with callable argument on passed-in task objects
+        """
+        roledefs = {'role1': ['a', 'b', 'c']}
+        role_copy = roledefs['role1'][:]
+        def gen():
+            return ['role1']
+        @roles(gen)
+        def task():
+            eq_(env.host_string, role_copy.pop(0))
+        with settings(hide('running'), roledefs=roledefs):
+            execute(task)
     @with_fakes
     def test_should_set_env_command_to_string_arg(self):
         """


### PR DESCRIPTION
This gets around the problem that you cannot define a host list inside
task being called.  For example, the following doesn't work:

```
@task
def foo():
    env.hosts = ['a', 'b', 'c']
    run('uptime')
```

However, now a user can define a method that returns hosts and pass
that to `@host`, example:

```
def get_ec2_hosts():
    DoSomeFancyStuffWithBoto()

@task
@hosts(get_ec2_hosts)
def foo():
    run('uptime')
```

The use case that I ran into was for generating env.hosts from a list of live ec2 instances.  I have tasks setup that create filters on `boto.ec2.get_all_instances()`, but the `get_all_instances()` shouldn't be called until the first time I need those hosts (so I can chain the tasks together, and so tasks that don't need it don't incur the overhead).

This way I can do something like:

```
fab dev web shutdown
```

to shutdown all my development web instances when it's time for me to sleep.
