### PR TITLE
Add env.flush to force flushing on puts()

### DIFF
--- a/fabric/state.py
+++ b/fabric/state.py
@@ -175,6 +175,12 @@ env_options = [
         help="Python module file to import, e.g. '../other.py'"
     ),
 
+    make_option('--flush',
+        action='store_true',
+        default=False,
+        help="Flush on all puts() calls"
+    ),
+
     make_option('-w', '--warn-only',
         action='store_true',
         default=False,
@@ -270,6 +276,7 @@ env = _AttributeDict({
     'cwd': '',  # Must be empty string, not None, for concatenation purposes
     'echo_stdin': True,
     'exclude_hosts': [],
+    'flush': False,
     'host': None,
     'host_string': None,
     'lcwd': '',  # Must be empty string, not None, for concatenation purposes

--- a/fabric/utils.py
+++ b/fabric/utils.py
@@ -93,7 +93,7 @@ def puts(text, show_prefix=True, end="\n", flush=False):
         if env.host_string and show_prefix:
             prefix = "[%s] " % env.host_string
         sys.stdout.write(prefix + str(text) + end)
-        if flush:
+        if flush or env.flush:
             sys.stdout.flush()
 
 


### PR DESCRIPTION
Without flushing, puts() is unreliable on non-standard terminals
(such as build systems). Forcing flushes resolves this issue.
