### PR TITLE
Avoid put() failures due to lost connection

### DIFF
--- a/fabric/sftp.py
+++ b/fabric/sftp.py
@@ -225,6 +225,11 @@ class SFTP(object):
         # Clean up
         if not local_is_path:
             os.remove(real_local_path)
+        if use_sudo:
+            with hide('everything'):
+                sudo("mv \"%s\" \"%s\"" % (remote_path, target_path))
+            # Revert to original remote_path for return value's sake
+            remote_path = target_path
         # Handle modes if necessary
         if (local_is_path and mirror_local_mode) or (mode is not None):
             lmode = os.stat(local_path).st_mode if mirror_local_mode else mode
@@ -236,11 +241,6 @@ class SFTP(object):
                         sudo('chmod %o \"%s\"' % (lmode, remote_path))
                 else:
                     self.ftp.chmod(remote_path, lmode)
-        if use_sudo:
-            with hide('everything'):
-                sudo("mv \"%s\" \"%s\"" % (remote_path, target_path))
-            # Revert to original remote_path for return value's sake
-            remote_path = target_path
         return remote_path
 
     def put_dir(self, local_path, remote_path, use_sudo, mirror_local_mode,


### PR DESCRIPTION
Fix permanent put() failure after aborted upload of write-protected files with use_sudo.

---

If a connection failure is encountered between the upload to a hashed file location (sftp.py:208-213; sftp.py:224) and the sudo move operation (sftp.py:239-243), any subsequent attempt to upload that file will fail if the file is write-protected.

The most direct solution appears to be performing the sudo move before changing file permissions, by swapping the order of the two if blocks. See commits/diff.
