### PR TITLE
Avoid "Resource temporarily unavailable" crashes in parallel mode

### DIFF
--- a/fabric/io.py
+++ b/fabric/io.py
@@ -125,11 +125,12 @@ def output_loop(chan, which, capture):
                     # Prompt for, and store, password. Give empty prompt so the
                     # initial display "hides" just after the actually-displayed
                     # prompt from the remote end.
+                    prev_input_enabled = chan.input_enabled
                     chan.input_enabled = False
                     password = fabric.network.prompt_for_password(
                         prompt=" ", no_colon=True, stream=pipe
                     )
-                    chan.input_enabled = True
+                    chan.input_enabled = prev_input_enabled
                     # Update env.password, env.passwords if necessary
                     set_password(password)
                     # Reset reprompt flag


### PR DESCRIPTION
I've found that I get crashes sometimes with "Resource temporarily unavailable" in parallel mode.

This particularly happens if one of the machines happens to prompt for a password. Of course that's something to be avoided, but it should also be recoverable. If I type the password, the process will continue as normal for a while, but then later it will crash with an IOError, "Resource temporarily unavailable".

I think the reason might be that the password code is setting `chan.input_enabled` to True when it is done, regardless of whether it was True before. If that's what's going on, this should fix the problem.
