### PR TITLE
fallback to rsync port = 22 when env.port = None

### DIFF
--- a/fabric/contrib/project.py
+++ b/fabric/contrib/project.py
@@ -92,7 +92,8 @@ def rsync_project(remote_dir, local_dir=None, exclude=(), delete=False,
             keys = [keys]
         key_string = "-i " + " -i ".join(keys)
     # Honor nonstandard port
-    port_string = ("-p %s" % env.port) if (env.port != '22' or env.port is not None) else "-p 22"
+    port_string = ("-p %s" % env.port) if (env.port != '22'
+    and env.port is not None ) else "-p 22"
     # RSH
     rsh_string = ""
     if key_string or port_string:


### PR DESCRIPTION
related to the fabric issue: fabric/fabric#494
