### PR TITLE
some PEP 8 love needed

### DIFF
--- a/fabric/operations.py
+++ b/fabric/operations.py
@@ -386,7 +386,7 @@ def put(local_path=None, remote_path=None, use_sudo=False,
         also exhibits the ``.failed`` and ``.succeeded`` attributes.
     """
     # Handle empty local path
-    local_path = local_path or os.getcwd()
+    local_path = local_path or env.lcwd or os.getcwd()
 
     # Test whether local_path is a path or a file-like object
     local_is_path = not (hasattr(local_path, 'read') \


### PR DESCRIPTION
### Description

running the `pep8` tool shows this:

```
sa@sub:~/0/python/fabric/fabric$ alias acsn; acsn pep8; pep8 *py
alias acsn='apt-cache search --names-only'
pep8 - Python PEP 8 code style checker
auth.py:10:1: E302 expected 2 blank lines, found 1
colors.py:19:80: E501 line too long (97 characters)
io.py:21:24: E225 missing whitespace around operator
io.py:97:63: E202 whitespace before ')'
main.py:17:23: E261 at least two spaces before inline comment
network.py:25:1: E303 too many blank lines (3)
network.py:55:1: W291 trailing whitespace
network.py:299:5: E301 expected 1 blank line, found 0
sftp.py:275:42: E231 missing whitespace after ','
version.py:95:24: W602 deprecated form of raising exception
sa@sub:~/0/python/fabric/fabric$ 
```

We should probably update `requirements.txt` and `fabfile.py` to include `pep8` and have a task for running it automatically on every commit. For more info on pep8: http://pypi.python.org/pypi/pep8

---

Originally submitted by **Markus Gattol** ([markusgattol](https://github.com/markusgattol)) on **2011-03-09** at **04:08am EST**

---

Closed as _Done_ on **2011-04-21** at **08:45pm EDT**
