### PR TITLE
Renamed second test_nested_alias() to test_nested_aliases()

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -355,7 +355,7 @@ class TestTaskAliases(FabricTest):
             ok_("foo_aliased" in funcs)
             ok_("foo_aliased_two" in funcs)
 
-    def test_nested_alias(self):
+    def test_nested_aliases(self):
         f = fabfile("nested_aliases.py")
         with path_prefix(f):
             docs, funcs = load_fabfile(f)


### PR DESCRIPTION
The 'tests.test_main.py' module has the 'TestTaskAliases' class. In that class there are TWO methods named 'test_flat_alias()', and I think the second should be called something like 'test_flat_aliases()'.

This pull request renames the second method.
