### PR TITLE
Takes account of the width of the current terminal for displaying the normal list

### DIFF
--- a/fabric/main.py
+++ b/fabric/main.py
@@ -26,6 +26,7 @@ from fabric.state import env_options
 from fabric.tasks import Task, execute
 from fabric.task_utils import _Dict, crawl
 from fabric.utils import abort, indent
+from fabric.operations import _pty_size
 
 # One-time calculation of "all internal callables" to avoid doing this on every
 # check of a given fabfile callable (in is_classic_task()).
@@ -385,13 +386,9 @@ def _normal_list(docstrings=True):
     sep = '  '
     trail = '...'
     max_width = 75
-    try:
-        output = subprocess.Popen(["stty", "size"], stdout=subprocess.PIPE).communicate()[0]
-        available_columns = int(output.split()[1])-1-len(trail)
-        if available_columns > max_width:
-            max_width = available_columns
-    except:
-        pass
+    available_columns = _pty_size()[1]-1-len(trail)
+    if available_columns > max_width:
+        max_width = available_columns
     for name in task_names:
         output = None
         docstring = _print_docstring(docstrings, name)


### PR DESCRIPTION
This works only on *nix, since I don't know any portable way to get the current width of the console. This doesn't depends on any external library, and use the "stty" program, available in most of the *nix.

In case of error, silently fails and use the default value of 75.

Running _-f tests/test_parallel.py --list_ changes from:

```
    Available commands:

    FabricTest    Nose-oriented test runner which wipes state.env and provid...
    TestParallel
    eq_           Shadow of the Nose builtin which presents easier to read m...
    server        Returns a decorator that runs an SSH server during functio...
```

to:

```
Available commands:

    FabricTest    Nose-oriented test runner which wipes state.env and provides file helpers.
    TestParallel
    eq_           Shadow of the Nose builtin which presents easier to read multiline output.
    server        Returns a decorator that runs an SSH server during function execution.
```
