### PR TITLE
Added import of 'normalize'

### DIFF
--- a/fabric/contrib/project.py
+++ b/fabric/contrib/project.py
@@ -7,7 +7,7 @@ import os.path
 from datetime import datetime
 from tempfile import mkdtemp
 
-from fabric.network import needs_host, key_filenames
+from fabric.network import needs_host, key_filenames, normalize
 from fabric.operations import local, run, put
 from fabric.state import env, output
 


### PR DESCRIPTION
Running rsync_project() fails with "NameError: global name 'normalize' is not defined" because of the forgotten import.

```
Traceback (most recent call last):
  File "/home/proj/python/fabric/fabric/main.py", line 710, in main
*args, **kwargs
  File "/home/proj/python/fabric/fabric/tasks.py", line 280, in execute
multiprocessing
  File "/home/proj/python/fabric/fabric/tasks.py", line 179, in _execute
return task.run(*args, **kwargs)
  File "/home/proj/python/fabric/fabric/tasks.py", line 112, in run
return self.wrapped(*args, **kwargs)
  File "/home/proj/python/fabric/fabric/decorators.py", line 65, in inner_decorator
return func(*args, **kwargs)
  File "/home/proj/python/fabric/fabtest.py", line 10, in test
rsync_project("/dev/shm", "docs")
  File "/home/proj/python/fabric/fabric/network.py", line 456, in host_prompting_wrapper
return func(*args, **kwargs)
  File "/home/proj/python/fabric/fabric/contrib/project.py", line 92, in rsync_project
user, host, port = normalize(env.host_string)
NameError: global name 'normalize' is not defined
```
