### PR TITLE
put(): treat trailing slash on local_path similary to rsync

### DIFF
--- a/fabric/operations.py
+++ b/fabric/operations.py
@@ -276,6 +276,16 @@ def put(local_path=None, remote_path=None, use_sudo=False,
         argument will cause a temporary file to be utilized due to limitations
         in our SSH layer's API.
 
+    .. note::
+        A trailing slash on the local_path is treated in the same way as
+        rsync - think of a trailing / on a source as meaning "copy the
+        contents of this directory" as opposed to "copy the directory by
+        name". In other words, each of the following commands copies the files
+        in the same way:
+
+            put('src/foo', 'dst')
+            put('src/foo/', 'dst/foo')
+
     ``remote_path`` may also be a relative or absolute location, but applied to
     the remote host. Relative paths are relative to the remote user's home
     directory, but tilde expansion (e.g. ``~/.ssh/``) will also be performed if

--- a/fabric/sftp.py
+++ b/fabric/sftp.py
@@ -254,6 +254,11 @@ class SFTP(object):
         else:
             strip = os.path.dirname(os.path.dirname(local_path))
 
+        # behave like rsync.  if the local path ends in /, avoid
+        # creating an additional directory layer on the remote side.
+        if local_path[-1:] == '/':
+            strip = os.path.join(strip, os.path.basename(local_path[:-1]))
+
         remote_paths = []
 
         for context, dirs, files in os.walk(local_path):


### PR DESCRIPTION
This allows us to do:
put('src/foo/', 'dst/bar')

rathern than:
put('src/foo', 'dst')
run('mv dst/foo dst/bar')

Signed-off-by: Bobby Powers bobbypowers@gmail.com
