### PR TITLE
with_settings decorator takes context managers

### DIFF
--- a/fabric/decorators.py
+++ b/fabric/decorators.py
@@ -188,7 +188,7 @@ def parallel(pool_size=None):
     return real_decorator
 
 
-def with_settings(**kw_settings):
+def with_settings(*arg_settings, **kw_settings):
     """
     Decorator equivalent of ``fabric.context_managers.settings``.
 
@@ -209,7 +209,7 @@ def with_settings(**kw_settings):
     def outer(func):
         @wraps(func)
         def inner(*args, **kwargs):
-            with settings(**kw_settings):
+            with settings(*arg_settings, **kw_settings):
                 return func(*args, **kwargs)
         return _wrap_as_new(func, inner)
     return outer

--- a/tests/test_context_managers.py
+++ b/tests/test_context_managers.py
@@ -2,8 +2,8 @@ from __future__ import with_statement
 
 from nose.tools import eq_, ok_
 
-from fabric.state import env
-from fabric.context_managers import cd, settings
+from fabric.state import env, output
+from fabric.context_managers import cd, settings, lcd
 
 
 #
@@ -75,3 +75,19 @@ def test_settings_with_multiple_kwargs():
         eq_(env.testval2, "inner 2")
     eq_(env.testval1, "outer 1")
     eq_(env.testval2, "outer 2")
+
+def test_settings_with_other_context_managers():
+    """
+    settings() should take other context managers, and use them with other overrided
+    key/value pairs.
+    """
+    env.testval1 = "outer 1"
+    prev_lcwd = env.lcwd
+
+    with settings(lcd("here"), testval1="inner 1"):
+        eq_(env.testval1, "inner 1")
+        ok_(env.lcwd.endswith("here")) # Should be the side-effect of adding cd to settings
+
+    ok_(env.testval1, "outer 1")
+    eq_(env.lcwd, prev_lcwd)
+


### PR DESCRIPTION
The with_settings() decorator from fabric.decorators takes keyword arguments to
set in the environment, and other context managers, much like the regular
settings context manager does. See issue #458 for more details.
