### PR TITLE
file.contains works with ~ in filename

### DIFF
--- a/fabric/contrib/files.py
+++ b/fabric/contrib/files.py
@@ -277,7 +277,7 @@ def contains(filename, text, exact=False, use_sudo=False):
     if exact:
         text = "^%s$" % text
     with settings(hide('everything'), warn_only=True):
-        return func('egrep "%s" "%s"' % (
+        return func('egrep "%s" "$(echo %s)"' % (
             text.replace('"', r'\"'),
             filename.replace('"', r'\"')
         )).succeeded


### PR DESCRIPTION
Fixed #367.Similar patch to this https://github.com/fabric/fabric/commit/0bc58aa11477ecb0f6c770fbce65822dfdc52498
