### PR TITLE
Fixed unicode error raised when using Jinja2 template with upload_template.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     url='http://fabfile.org',
     packages=find_packages(),
     test_suite='nose.collector',
-    tests_require=['nose', 'fudge<1.0'],
+    tests_require=['nose', 'fudge<1.0', 'Jinja2'],
     install_requires=['ssh>=1.7.12'],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Hi,
I've stumbled upon this issue recently. The issue appears when using non-ascii characters on Jinja2 template.
In fact, when trying to submit data through SFTP connection, the resulted StringIO - passed to put function - is converted to bytes (str) which raise the exception.
The documentation says that temporary files are used when dealing with template, but the code was missing. I've added the code to deal with temporary files and a test.
Feel free to merge and to give any feedback on the patch.
Regards,
Sébastien
