### PR TITLE
Add ec2_tags decorator

### DIFF
--- a/docs/usage/execution.rst
+++ b/docs/usage/execution.rst
@@ -136,6 +136,34 @@ situations where you have common groupings of servers.
 .. versionchanged:: 0.9.2
     Added ability to use callables as ``roledefs`` values.
 
+
+.. _ec2-tags:
+
+EC2 tags
+--------
+
+The ``ec2_tags`` decorator can be used to execute tasks on a number of EC2
+instances, using EC2 tags. Assuming your instances have a 'role' tag with a
+value of 'webserver', this would execute the task on all webserver instances::
+    
+    from fabric.api import ec2_tags
+
+    @ec2_tags({'role': 'webserver'})
+    def my_task():
+        pass
+
+By default, this will search for your instances in all EC2 regions. This is
+inefficient if you only have instances in a couple of regions. The region list
+is stored in env so it can be easily updated. The following task would only
+search the Western Europe EC2 region::
+
+    env.ec2_regions = ['eu-west-1']
+
+    @ec2_tags({'role': 'webserver'})
+    def my_task():
+        pass
+
+
 .. _host-lists:
 
 How host lists are constructed

--- a/fabric/api.py
+++ b/fabric/api.py
@@ -8,7 +8,7 @@ well when you're using setup.py to install e.g. ssh!
 """
 from fabric.context_managers import cd, hide, settings, show, path, prefix, lcd
 from fabric.decorators import (hosts, roles, runs_once, with_settings, task, 
-        serial, parallel)
+        serial, parallel, ec2_tags)
 from fabric.operations import (require, prompt, put, get, run, sudo, local,
     reboot, open_shell)
 from fabric.state import env, output

--- a/fabric/state.py
+++ b/fabric/state.py
@@ -278,6 +278,8 @@ env = _AttributeDict({
     'cwd': '',  # Must be empty string, not None, for concatenation purposes
     'default_port': default_port,
     'echo_stdin': True,
+    'ec2_regions': ['eu-west-1', 'us-east-1', 'us-west-1', 'us-west-2', 
+        'sa-east-1', 'ap-southeast-1'],
     'exclude_hosts': [],
     'host': None,
     'host_string': None,


### PR DESCRIPTION
Amazon's EC2 allows you to tag instances with user-defined tags. Many people use this to define roles for their instances, for example my instances are tagged "role=webserver", "role=dbserver" etc.

This commit adds an ec2_tags decorator, which can be used to execute the task on all hosts that match the given tags, for example:

@ec2_tags({'role': 'webserver'})
def get_hostname()
    run('hostname')

I'm not sure if there is any interest in having something like this in Fabric's core - if there is, I would be happy to make any suggested changes/improvements. I have also included very basic documentation.
