### PR TITLE
allow a sudo_prefix that doesn't include sudo_prompt

### DIFF
--- a/fabric/operations.py
+++ b/fabric/operations.py
@@ -579,7 +579,7 @@ def _sudo_prefix(user):
     Return ``env.sudo_prefix`` with ``user`` inserted if necessary.
     """
     # Insert env.sudo_prompt into env.sudo_prefix
-    prefix = env.sudo_prefix % env.sudo_prompt
+    prefix = env.sudo_prefix % env
     if user is not None:
         if str(user).isdigit():
             user = "#%s" % user

--- a/fabric/state.py
+++ b/fabric/state.py
@@ -295,7 +295,7 @@ env = _AttributeDict({
     'ssh_config_path': default_ssh_config_path,
     # -S so sudo accepts passwd via stdin, -p with our known-value prompt for
     # later detection (thus %s -- gets filled with env.sudo_prompt at runtime)
-    'sudo_prefix': "sudo -S -p '%s' ",
+    'sudo_prefix': "sudo -S -p '%(sudo_prompt)s' ",
     'sudo_prompt': 'sudo password:',
     'use_exceptions_for': {'network': False},
     'use_shell': True,


### PR DESCRIPTION
I added a NOPASSWD entry in my sudoers file to allow a particular command to be run as root. as per http://stackoverflow.com/questions/3737003/can-i-prevent-fabric-from-prompting-me-for-a-sudo-password , I had to add shell=False to run the command 'as-is'.

However, with the latest version of Fabric (1.4.0), it's not possible to prevent Fabric from passing the "-p" option to sudo, which makes it ask for a password even if none is needed.

I tried setting env.sudo_prefix, but this doesn't work because _sudo_prefix() in operations.py does

```
prefix = env.sudo_prefix % env.sudo_prompt
```

In other words, the sudo_prefix string has to contain a '%s' for interpolation.

Using the approach in this pull request will also make it easier to document sudo_prefix and I think making all env vars available to sudo_prefix is cool, especially since you're planning to document it (https://github.com/fabric/fabric/issues/564)
