### PR TITLE
Include username in default password prompt

### DIFF
--- a/fabric/network.py
+++ b/fabric/network.py
@@ -413,7 +413,7 @@ def prompt_for_password(prompt=None, no_colon=False, stream=None):
     handle_prompt_abort("a connection or sudo password")
     stream = stream or sys.stderr
     # Construct prompt
-    default = "[%s] '%s' password" % (env.host_string, env.user)
+    default = "[%s] Login password for '%s'" % (env.host_string, env.user)
     password_prompt = prompt if (prompt is not None) else default
     if not no_colon:
         password_prompt += ": "


### PR DESCRIPTION
It is impossible to say what user the password is being asked for when the default password prompt is used. This is a tiny patch that will print the username when asking for a password.
