### PR TITLE
Fixes #249 - Adds remote program timeout.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,6 +25,8 @@ would have also been included in the 1.2 line.
 Changelog
 =========
 
+* :feature:`249` Allow specification of remote command timeout value by
+  setting :ref:`env.command_timeout <command_timeout>`.
 * :feature:`646` Allow specification of which local streams to use when
   `~fabric.operations.run`/`~fabric.operations.sudo` print the remote
   stdout/stderr, via e.g. ``run("command", stderr=sys.stdout)``.

--- a/docs/usage/env.rst
+++ b/docs/usage/env.rst
@@ -182,6 +182,18 @@ executed by `~fabric.operations.run`/`~fabric.operations.sudo`.
 
 .. versionadded:: 1.0
 
+.. _command-timeout:
+
+``command_timeout``
+-----------
+
+**Default:** ``10``
+
+Network connection timeout, in seconds.
+
+.. versionadded:: 1.5
+.. seealso:: :option:`--command-timeout`
+
 .. _connection-attempts:
 
 ``connection_attempts``

--- a/docs/usage/fab.rst
+++ b/docs/usage/fab.rst
@@ -304,6 +304,15 @@ below.
         :ref:`env.connection_attempts <connection-attempts>`
     .. versionadded:: 1.4
 
+.. cmdoption:: --command-timeout=N, -T N
+
+   Set remote command timeout in seconds. Sets
+   :ref:`env.command_timeout <command_timeout>`.
+
+   .. seealso::
+	:ref:`env.command_timeout <command_timeout>`,
+    .. versionadded:: 1.5
+
 .. cmdoption:: -u USER, --user=USER
 
     Sets :ref:`env.user <user>` to the given string; it will then be used as the

--- a/fabric/state.py
+++ b/fabric/state.py
@@ -231,6 +231,14 @@ env_options = [
         help="set connection timeout to N seconds"
     ),
 
+    make_option('-T', '--command-timeout',
+        dest='command_timeout',
+        type='int',
+        default=None,
+        metavar="N",
+        help="set remote command timeout to N seconds"
+    ),
+
     make_option('-u', '--user',
         default=_get_system_username(),
         help="username to use when connecting to remote hosts"
@@ -340,6 +348,7 @@ def default_channel():
     Return a channel object based on ``env.host_string``.
     """
     chan = connections[env.host_string].get_transport().open_session()
+    chan.settimeout(env.command_timeout)
     chan.input_enabled = True
     return chan
 


### PR DESCRIPTION
Adds env.command_timeout which sets the timeout value for remotely
running commands (see #249).
