### PR TITLE
Documenting how to not create a backup with `sed`

### DIFF
--- a/fabric/contrib/files.py
+++ b/fabric/contrib/files.py
@@ -127,7 +127,8 @@ def sed(filename, before, after, limit='', use_sudo=False, backup='.bak',
     Run a search-and-replace on ``filename`` with given regex patterns.
 
     Equivalent to ``sed -i<backup> -r -e "/<limit>/ s/<before>/<after>/<flags>g
-    <filename>"``.
+    <filename>"``. Setting ``backup`` to an empty string will, disable backup
+    file creation.
 
     For convenience, ``before`` and ``after`` will automatically escape forward
     slashes, single quotes and parentheses for you, so you don't need to


### PR DESCRIPTION
Really, this is documented in the `sed` command line utility man page,
but I still think it's a valuable piece of information to add to
fabric's documentation.
