### PR TITLE
shell_env context manager

### DIFF
--- a/fabric/context_managers.py
+++ b/fabric/context_managers.py
@@ -421,6 +421,18 @@ def char_buffered(pipe):
             termios.tcsetattr(pipe, termios.TCSADRAIN, old_settings)
 
 
+def shell_env(**kw):
+    """
+    Set shell environment variables for all wrapped commands.
+
+    ::
+
+      with shell_env(ZMQ_DIR='/home/user/local'):
+          run('pip install pyzmq')
+    """
+    return _setenv(shell_env=kw)
+
+
 quiet = lambda: settings(hide('everything'), warn_only=True)
 quiet.__doc__ = """
     Alias to ``settings(hide('everything'), warn_only=True)``.

--- a/fabric/state.py
+++ b/fabric/state.py
@@ -292,6 +292,7 @@ env = _AttributeDict({
     'real_fabfile': None,
     'roles': [],
     'roledefs': {},
+    'shell_env': {},
     'skip_bad_hosts': False,
     'ssh_config_path': default_ssh_config_path,
     # -S so sudo accepts passwd via stdin, -p with our known-value prompt for

--- a/tests/test_context_managers.py
+++ b/tests/test_context_managers.py
@@ -3,7 +3,7 @@ from __future__ import with_statement
 from nose.tools import eq_, ok_
 
 from fabric.state import env, output
-from fabric.context_managers import cd, settings, lcd, hide
+from fabric.context_managers import cd, settings, lcd, hide, shell_env
 
 
 #
@@ -130,6 +130,17 @@ def test_settings_clean_revert():
     eq_(env.modified, "modified internally")
     ok_("inner_only" not in env)
 
+#
+# shell_env()
+#
+def test_shell_env():
+    """
+    shell_env() sets the shell_env attribute in the env dict
+    """
+    with shell_env(KEY="value"):
+        eq_(env.shell_env['KEY'], 'value')
+
+    eq_(env.shell_env, {})
 
 from fabric.operations import run
 from fabric.context_managers import quiet


### PR DESCRIPTION
Here's my implementation of the shell_env context manager. I merged the logic for the path context manager in to the same code since they do nearly the same thing.

Added a basic test, though there should probably be something to actually test the command that's generated I didn't see any examples of similar tests for how to do that.

For GH-263
