### PR TITLE
move temp sudo put files to /tmp

### DIFF
--- a/fabric/sftp.py
+++ b/fabric/sftp.py
@@ -212,7 +212,7 @@ class SFTP(object):
             hasher = hashlib.sha1()
             hasher.update(env.host_string)
             hasher.update(target_path)
-            remote_path = hasher.hexdigest()
+            remote_path = "/tmp/" + hasher.hexdigest()
         # Have to bounce off FS if doing file-like objects
         fd, real_local_path = None, local_path
         if not local_is_path:


### PR DESCRIPTION
When creating a temporary file on the remote host, it should go into a temporary directory. I ran into this problem because I didn't have write access to whatever directory it was trying to access.
