### PR TITLE
require() only checks for existence of key, not empty value

### DIFF
--- a/fabric/operations.py
+++ b/fabric/operations.py
@@ -94,8 +94,9 @@ def require(*keys, **kwargs):
     .. versionchanged:: 1.1
         Allow iterable ``provided_by`` values instead of just single values.
     """
-    # If all keys exist, we're good, so keep going.
-    missing_keys = filter(lambda x: x not in env, keys)
+    # If all keys exist and are non-empty, we're good, so keep going.
+    missing_keys = filter(lambda x: x not in env or (x in env and
+        isinstance(env[x], (dict, list, tuple, set)) and not env[x]), keys)
     if not missing_keys:
         return
     # Pluralization

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -104,6 +104,64 @@ def test_require_noniterable_provided_by_key():
     require('foo', provided_by=fake_providing_function)
 
 
+@aborts
+def test_require_key_exists_empty_list():
+    """
+    When given a single existing key but the value is an empty list, require()
+    aborts
+    """
+    # 'hosts' is one of the default values, so we know it'll be there
+    require('hosts')
+
+
+@aborts
+@with_settings(foo={})
+def test_require_key_exists_empty_dict():
+    """
+    When given a single existing key but the value is an empty dict, require()
+    aborts
+    """
+    require('foo')
+
+
+@aborts
+@with_settings(foo=())
+def test_require_key_exists_empty_tuple():
+    """
+    When given a single existing key but the value is an empty tuple, require()
+    aborts
+    """
+    require('foo')
+
+
+@aborts
+@with_settings(foo=set())
+def test_require_key_exists_empty_set():
+    """
+    When given a single existing key but the value is an empty set, require()
+    aborts
+    """
+    require('foo')
+
+
+@with_settings(foo=0, bar=False)
+def test_require_key_exists_false_primitive_values():
+    """
+    When given keys that exist with primitive values that evaluate to False,
+    require() throws no exception
+    """
+    require('foo', 'bar')
+
+
+@with_settings(foo=['foo'], bar={'bar': 'bar'}, baz=('baz',), qux=set('qux'))
+def test_require_complex_non_empty_values():
+    """
+    When given keys that exist with non-primitive values that are not empty,
+    require() throws no exception
+    """
+    require('foo', 'bar', 'baz', 'qux')
+
+
 #
 # prompt()
 #


### PR DESCRIPTION
If the title is cryptic, I hope a simple example will explain:

``` python
from fabric.api import *

def staging():
    pass

def deploy():
    require('hosts', provided_by=[staging])
```

Running `fab deploy` will complete successfully even though `hosts` was never provided. This is because Fabric itself inserts an empty list at `env['hosts']` and the require function only checks for the existence of the key, not the value. This is the code as of [today](https://github.com/fabric/fabric/blob/master/fabric/operations.py#L98):

``` python
missing_keys = filter(lambda x: x not in env, keys)
```

This can be improved by checking the value but would require some type-checking to ensure that values of 0 and False are handled appropriately, though it's not particularly Pythonic.

Modifying the lambda would look something like this:

``` python
missing_keys = filter(lambda x: (x in env and isinstance(env[x], (types.DictType, types.ListType, types.TupleType)) and not env[x]) or x not in env, keys)
```

It's probably better to use a simple for-loop as that lambda is abusive.

I've opened this issue without a patch to see if this is something you think should be pursued. If so, I'd be happy to write up a patch and corresponding tests.

I ran into the issue with the `hosts` key but I would expect that users who use `require` actually care that the value is not empty, not simply that the key exists.

In any event, thanks for the great package.
