### PR TITLE
contrib.files.append([...], use_sudo_=True) does not work with 'cd()' ctx manager

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,6 +25,8 @@ would have also been included in the 1.2 line.
 Changelog
 =========
 
+* :bug:`703` Add a ``shell`` kwarg to many methods in `~fabric.contrib.files`
+  to help avoid conflicts with `~fabric.context_managers.cd` and similar.
 * :bug:`702` `~fabric.operations.require` failed to test for "empty" values in
   the env keys it checks (e.g.
   ``require('a-key-whose-value-is-an-empty-list')`` would register a successful


### PR DESCRIPTION
``` python
with settings(user=some_user), cd('/home/some_user'):
    append('.ssh/authorized_keys', key, partial=True, use_sudo=use_sudo)
```

This code silently duplicates existing key in a checked file. The full resulting command is:

```
sudo -S -p 'sudo password:'  cd /home/some_user && egrep "^ssh\-rsa\ AAAAB3Nza[...]jN\+v7w\=\=" ".ssh/authorized_keys"
```

(as returned by _shell_wrap() call) The problem is: normally, there is no standalone 'cd' command in UNIX, as it is a shell built-in. And ommiting context manager `#with settings(hide('everything'), warn_only=True):` at the end of `contains()` reveals that.

Quick test to use `shell=True` in the final call inside `contains()` fixes that, but possibly has other side-effects.
