### PR TITLE
Fix sftp put_dir for fabric run on windows

### DIFF
--- a/fabric/sftp.py
+++ b/fabric/sftp.py
@@ -271,8 +271,8 @@ class SFTP(object):
 
         for context, dirs, files in os.walk(local_path):
             rcontext = context.replace(strip, '', 1)
-            rcontext = rcontext.lstrip('/')
-            rcontext = posixpath.join(remote_path, rcontext)
+            rcontext = rcontext.lstrip(os.sep)
+            rcontext = posixpath.join(remote_path, *os.path.split(rcontext))
 
             if not self.exists(rcontext):
                 self.mkdir(rcontext, use_sudo)


### PR DESCRIPTION
Fix local directory strip and splits

because rcontext is local file, it should use os.sep instead of '/' for determining what to split. Also splitting the path with os.split before passing to posipath.join
