### PR TITLE
Allows the creation of custom prompts and responses to allow custom prompts for contextmanagers.

### DIFF
--- a/fabric/io.py
+++ b/fabric/io.py
@@ -36,14 +36,14 @@ def _was_newline(capture, byte):
     endswith_newline = _endswith(capture, '\n') or _endswith(capture, '\r')
     return endswith_newline and not _is_newline(byte)
 
-def _get_prompt_response(capture, request_prompts):
+def _get_prompt_response(capture, prompt_responses):
     """
     Iterate through the request prompts dict and return the response and
     original request if we find a match
     """
-    for request_prompt in request_prompts.keys():
+    for request_prompt in prompt_responses.keys():
         if _endswith(capture, request_prompt):
-            return (request_prompt, request_prompts[request_prompt])
+            return (request_prompt, prompt_responses[request_prompt])
     return None
 
 def output_loop(chan, attr, stream, capture):
@@ -112,7 +112,7 @@ def output_loop(chan, attr, stream, capture):
             # Store in internal buffer
             _buffer += byte
             # Handle prompts
-            prompt_pair = _get_prompt_response(capture, env['request_prompts'])
+            prompt_pair = _get_prompt_response(capture, env['prompt_responses'])
             if prompt_pair:
                 del capture[-1 * len(prompt_pair[0]):]
                 chan.sendall(str(prompt_pair[1]) + '\n')

--- a/fabric/state.py
+++ b/fabric/state.py
@@ -302,7 +302,7 @@ env = _AttributeDict({
     'sudo_prefix': "sudo -S -p '%(sudo_prompt)s' ",
     'sudo_prompt': 'sudo password:',
     'sudo_user': None,
-    'request_prompts' : {},
+    'prompt_responses' : {},
     'use_exceptions_for': {'network': False},
     'use_shell': True,
     'use_ssh_config': False,

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -7,9 +7,9 @@ def test_request_prompts():
     Test valid responses from prompts
     """
     ad = _AliasDict(
-    {'request_prompts' : { "prompt2" : "response2","prompt1" : "response1" ,"prompt": "response" } }
+    {'prompt_responses' : { "prompt2" : "response2","prompt1" : "response1" ,"prompt": "response" } }
         )
-    eq_(_get_prompt_response(list("this is a prompt for prompt1"), ad['request_prompts']), ("prompt1","response1"))
-    eq_(_get_prompt_response(list("this is a prompt for prompt2"), ad['request_prompts']), ("prompt2","response2"))
-    eq_(_get_prompt_response(list("this is a prompt for promptx:"), ad['request_prompts']), None)
-    eq_(_get_prompt_response(list("prompt for promp"), ad['request_prompts']), None)
+    eq_(_get_prompt_response(list("this is a prompt for prompt1"), ad['prompt_responses']), ("prompt1","response1"))
+    eq_(_get_prompt_response(list("this is a prompt for prompt2"), ad['prompt_responses']), ("prompt2","response2"))
+    eq_(_get_prompt_response(list("this is a prompt for promptx:"), ad['prompt_responses']), None)
+    eq_(_get_prompt_response(list("prompt for promp"), ad['prompt_responses']), None)


### PR DESCRIPTION
Allows the creation of custom prompts and responses. I wrote it to allow custom contextmanagers as in the following example:

``` python
from fabric.api import env, run
import contextlib

@contextlib.contextmanager
def asu(user, asu_number):
    '""custom ASU wrapper around sudo"""

    save_shell = env.shell

    save_current_prompts = env.prompt_responses
    env.prompt_responses = { "Enter ASU #:" : asu_number, "Password:" : "testpassword" }

    env.shell = '$HOME/asu  %s -c' % user
    yield
    env.shell = save_shell
    env.prompt_responses = save_current_prompts
```

And in the fab file:

```
with asu("root",asu_number):
      run("touch /var/tmp/test.touch")
```
