### PR TITLE
Adding support to shell_env on Windows

### DIFF
--- a/fabric/operations.py
+++ b/fabric/operations.py
@@ -676,7 +676,7 @@ def _prefix_env_vars(command):
         exp_cmd = '' if win32 else 'export '
 
         exports = ' '.join(
-            '%s%s="%s"' % (set_cmd, k, _shell_escape(v))
+            '%s%s="%s"' % (set_cmd, k, v if k == 'PATH' else _shell_escape(v))
             for k, v in env_vars.iteritems()
         )
         shell_env_str = '%s%s && ' % (exp_cmd, exports)


### PR DESCRIPTION
The context manager `shell_env` uses an `export` command, and this does not work on Windows.

Windows uses the sintax `SET name="value"` that is almost identical to the Linux counterpart.

Tested on Windows 7.
