### PR TITLE
getpass.getpass() prompt on windows expects char not unicode

### DIFF
--- a/fabric/network.py
+++ b/fabric/network.py
@@ -485,12 +485,12 @@ def prompt_for_password(prompt=None, no_colon=False, stream=None):
     if not no_colon:
         password_prompt += ": "
     # Get new password value
-    new_password = getpass.getpass(password_prompt, stream)
+    new_password = getpass.getpass(password_prompt.encode('ascii','ignore'), stream)
     # Otherwise, loop until user gives us a non-empty password (to prevent
     # returning the empty string, and to avoid unnecessary network overhead.)
     while not new_password:
         print("Sorry, you can't enter an empty password. Please try again.")
-        new_password = getpass.getpass(password_prompt, stream)
+        new_password = getpass.getpass(password_prompt.encode('ascii','ignore'), stream)
     return new_password
 
 


### PR DESCRIPTION
Traceback:

> File "C:\Python27\Lib\site-packages\fabric\network.py", line 488, in prompt_for_password
> new_password = getpass.getpass(password_prompt, stream)
> File "C:\Python27\Lib\getpass.py", line 95, in win_getpass
> msvcrt.putch(c)
> TypeError: must be char, not unicode

I've just converted the prompt text to ASCII with `password_prompt.encode('ascii','ignore')`, but perhaps there's a nicer solution. Haven't tested on Linux.
