### PR TITLE
Allow forwarding of CLTR-C (SIGINT) to the remote process.

### DIFF
--- a/fabric/state.py
+++ b/fabric/state.py
@@ -314,6 +314,7 @@ env = _AttributeDict({
     'path_behavior': 'append',
     'port': default_port,
     'real_fabfile': None,
+    'remote_interrupt': None,
     'roles': [],
     'roledefs': {},
     'shell_env': {},


### PR DESCRIPTION
This feature is controlled by the env.remote_interupt variable. The default
value is None, which means that it depends on the value of the "invoke_shell"
parameter.

If no PTY is allocated, then remote interrupts will always be disabled.

If remote interrupts are enabled, then a CTRL-C pressed on the local terminal will deliver a SIGINT to the remote process, rather than terminating the local Fabric IO loop.
