### PR TITLE
Add a 'role' attribute to env.host_string

### DIFF
--- a/fabric/utils.py
+++ b/fabric/utils.py
@@ -350,3 +350,17 @@ class RingBuffer(list):
             raise ValueError("Can't set a slice of a ring buffer!")
         else:
             return self._super.__setitem__(key, value)
+
+
+class HostString(str):
+    """
+    A subclass of :class:`str` used to store host strings.
+
+    It adds a :attr:`role` attribute, to be able to retrieve which role the
+    host was selected from.
+    """
+
+    def __new__(self, value, role=None):
+        ret = super(HostString, self).__new__(self, value)
+        ret.role = role
+        return ret

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -312,6 +312,35 @@ def test_lazy_roles():
         pass
     eq_hosts(command, ['a', 'b'], env={'roledefs': lazy_role})
 
+def test_host_string_role_attr():
+    """
+    Role from which a host was selected can be retrieved with the host
+    string's role attribute.
+    """
+    # Hosts list built from roles
+    fake_env = {'roledefs': {'role1': ['a'], 'role2': ['a']}}
+    hosts = get_hosts(dummy, [], ['role1'], [], fake_env)
+    eq_(hosts, ['a'])
+    eq_(hosts[0].role, 'role1')
+    hosts = get_hosts(dummy, [], ['role2'], [], fake_env)
+    eq_(hosts, ['a'])
+    eq_(hosts[0].role, 'role2')
+    # Hosts list built from hosts
+    hosts = get_hosts(dummy, ['host'], [], [])
+    eq_(hosts, ['host'])
+    eq_(hosts[0].role, None)
+    hosts = get_hosts(dummy, [], [], [], {'hosts': ['host']})
+    eq_(hosts, ['host'])
+    eq_(hosts[0].role, None)
+    # Hosts list built from roles + hosts
+    hosts = get_hosts(dummy, ['b'], ['role1'], [], fake_env)
+    eq_(hosts, ['b', 'a'])
+    eq_(hosts[0].role, None)
+    eq_(hosts[1].role, 'role1')
+    # Hosts list built from roles + hosts (with duplicates)
+    hosts = get_hosts(dummy, ['a'], ['role1'], [], fake_env)
+    eq_(hosts, ['a'])
+    eq_(hosts[0].role, None)
 
 #
 # Fabfile loading


### PR DESCRIPTION
This allows to know the 'current' role in a task.

Here is an example use case:

``` python
from fabric.api import env, sudo
from fabric.decorators import roles

env.dedupe_hosts = False

env.roledefs = {
    'web': ['webhost.example.com'],
    'worker': ['webhost.example.com', 'workers.example.com'],
}

def prod():
    env.prog_name = {
        'web': 'webapp',
        'worker': 'webapp-worker',
    }

def preprod():
    env.prog_name = {
        'web': 'webapp-preprod',
        'worker': 'webapp-worker-preprod',
    }

@roles('web', 'worker')
def restart():
    prog_name = env.prog_name[env.host_string.role]
    sudo('supervisorctl restart %s' % prog_name)
```

If env.host_string had no 'role' attribute we would have to guess it by searching env.host_string in env.roledefs. It would not work in this case because 'webhost.example.com' is present in both 'web' and 'worker' roles.

In the example above, the restart task will be executed 3 times, with env.host_string.role taking values ['web', 'worker', 'worker'].

I included a test in the commit, let me know if you accept the pull request and I will write documentation too.
