### PR TITLE
Downstream synchronization for rsync_project.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,6 +25,8 @@ would have also been included in the 1.2 line.
 Changelog
 =========
 
+* :feature:`845` Downstream synchronization option implemented for
+  `~fabric.contrib.project.rsync_project`.
 * :bug:`843` Ensure string ``pool_size`` values get run through ``int()``
   before deriving final result (stdlib ``min()`` has odd behavior here...).
   Thanks to Chris Kastorff for the catch.

--- a/fabric/contrib/project.py
+++ b/fabric/contrib/project.py
@@ -17,7 +17,7 @@ __all__ = ['rsync_project', 'upload_project']
 
 @needs_host
 def rsync_project(remote_dir, local_dir=None, exclude=(), delete=False,
-    extra_opts='', ssh_opts='', capture=False):
+    extra_opts='', ssh_opts='', capture=False, upload=True):
     """
     Synchronize a remote directory with the current project directory via rsync.
 
@@ -68,6 +68,8 @@ def rsync_project(remote_dir, local_dir=None, exclude=(), delete=False,
     * ``ssh_opts``: Like ``extra_opts`` but specifically for the SSH options
       string (rsync's ``--rsh`` flag.)
     * ``capture``: Sent directly into an inner `~fabric.operations.local` call.
+    * ``upload``: a boolean controlling whether file synchronization is
+      performed up or downstream. Upstream by default.
 
     Furthermore, this function transparently honors Fabric's port and SSH key
     settings. Calling this function when the current host string contains a
@@ -120,9 +122,14 @@ def rsync_project(remote_dir, local_dir=None, exclude=(), delete=False,
     if host.count(':') > 1:
         # Square brackets are mandatory for IPv6 rsync address,
         # even if port number is not specified
-        cmd = "rsync %s %s [%s@%s]:%s" % (options, local_dir, user, host, remote_dir)
+        remote_prefix = "[%s@%s]" % (user, host)
     else:
-        cmd = "rsync %s %s %s@%s:%s" % (options, local_dir, user, host, remote_dir)
+        remote_prefix = "%s@%s" % (user, host)
+    if upload:
+        cmd = "rsync %s %s %s:%s" % (options, local_dir, remote_prefix, remote_dir)
+    else:
+        cmd = "rsync %s %s:%s %s" % (options, remote_prefix, remote_dir, local_dir)
+
     if output.running:
         print("[%s] rsync_project: %s" % (env.host_string, cmd))
     return local(cmd, capture=capture)


### PR DESCRIPTION
rsync_project signature includes new 'upload' parameter with default
value 'True' so to keeps backwards compatibility. When set to 'False',
local directory is synchronized with remote, instead of the other way
around.

Implements issue #845.

Here is a [script](https://gist.github.com/apbarrero/5071643#file-test_rsync-py) testing the feature and the [output](https://gist.github.com/apbarrero/5071656#file-gistfile1-txt) when run in my system.
