### PR TITLE
template_dir for non jinja2 templates location

### DIFF
--- a/fabric/contrib/files.py
+++ b/fabric/contrib/files.py
@@ -106,7 +106,7 @@ def upload_template(filename, destination, context=None, use_jinja=False,
             abort(tb + "\nUnable to import Jinja2 -- see above.")
     else:
         if template_dir:
-            filename = template_dir + "/" + filename
+            filename = os.path.join(template_dir, filename)
         with open(filename) as inputfile:
             text = inputfile.read()
         if context:


### PR DESCRIPTION
_template_dir_ seems to be used only for jinja2 templates.
if _template_dir_ is set and _jinja2=False_ templates load always from _CWD_.

Fix to load templates from given location also for non jinja2 templates.
