### PR TITLE
Not calling task when args are missing

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -40,7 +40,7 @@ While we may not always reply promptly, we do try to make time eventually to
 inspect all contributions and either incorporate them or explain why we don't
 feel the change is a good fit.
 
-.. include:: ../CONTRIBUTING
+.. include:: ../CONTRIBUTING.rst
 
 Coding style
 ------------

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -109,6 +109,35 @@ class TestWrappedCallableTask(unittest.TestCase):
         task = WrappedCallableTask(foo)
         eq_(task(), task.run())
 
+    def test_calling_with_wrong_arg_count_returns_NotImplemented(self):
+        def foo(a, b, c): return 'great value'
+
+        task = WrappedCallableTask(foo)
+        eq_(task(), NotImplemented)
+
+    def test_calling_kwargs_with_args_returns_NotImplemented(self):
+        def bar(**kwargs): return 'great value'
+        task = WrappedCallableTask(bar)
+        eq_(task(1, 2, 3), NotImplemented)
+
+    def test_calling_with_right_arg_count_calls_callable(self):
+        def foo(a, b, c): return 'great value'
+        task = WrappedCallableTask(foo)
+        eq_(task(2, 2, 3), 'great value')
+
+    def test_calling_with_args_or_kwargs_calls_callable(self):
+        def foo(*args): return 'great value'
+        def bar(**kwargs): return 'great value'
+        task = WrappedCallableTask(foo)
+        eq_(task(1, 2, 3), 'great value')
+
+        task = WrappedCallableTask(bar)
+        eq_(task(a=1, b=2, c=3), 'great value')
+
+    def test_calling_with_builtin_calls_callable(self):
+        task = WrappedCallableTask(any)
+        eq_(task([True]), True)
+
 
 class TestTask(unittest.TestCase):
     def test_takes_an_alias_kwarg_and_wraps_it_in_aliases_list(self):


### PR DESCRIPTION
Not sure if this is something useful to others. I don't like the rather unfriendly traceback and `TypeError: foo() takes exactly 2 arguments (7 given)` message - this provides something different.

I don't like the use of NotImplemented as a sentinel value, but I'm not sure what else would make sense. I could do something awful, like `object()`, but the intent is no where near as clear.
