### PR TITLE
Fix to respect 'template_dir' for non Jinja2 templates (#852)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,6 +25,8 @@ would have also been included in the 1.2 line.
 Changelog
 =========
 
+* :bug:`852` Fix to respect 'template_dir' for non Jinja2 templates. Thanks to
+  Adam Kowalski for the patch.
 * :release:`1.6.0 <2013-03-01>`
 * :release:`1.5.4 <2013-03-01>`
 * :bug:`844` Account for SSH config overhaul in Paramiko 1.10 by e.g. updating

--- a/fabric/contrib/files.py
+++ b/fabric/contrib/files.py
@@ -61,7 +61,9 @@ def upload_template(filename, destination, context=None, use_jinja=False,
 
     Alternately, if ``use_jinja`` is set to True and you have the Jinja2
     templating library available, Jinja will be used to render the template
-    instead. Templates will be loaded from the invoking user's current working
+    instead.
+
+    Templates will be loaded from the invoking user's current working
     directory by default, or from ``template_dir`` if given.
 
     The resulting rendered file will be uploaded to the remote file path
@@ -105,6 +107,8 @@ def upload_template(filename, destination, context=None, use_jinja=False,
             tb = traceback.format_exc()
             abort(tb + "\nUnable to import Jinja2 -- see above.")
     else:
+        if template_dir:
+            filename = os.path.join(template_dir, filename)
         with open(filename) as inputfile:
             text = inputfile.read()
         if context:


### PR DESCRIPTION
- fix applied
- entry to changelog added
