### PR TITLE
Added keyword argument, default_opts, to rsync_project.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -26,7 +26,7 @@ Changelog
 =========
 
 * :feature: Added a keyword argument to rsync_project to configure the default
-  options.
+  options. Thanks to ``@moorepants`` for the patch.
 * :release:`1.7.0 <2013-07-26>`
 * :release:`1.6.2 <2013-07-26>`
 * :feature:`925` Added `contrib.files.is_link <.is_link>`. Thanks to `@jtangas`

--- a/fabric/contrib/project.py
+++ b/fabric/contrib/project.py
@@ -17,8 +17,8 @@ __all__ = ['rsync_project', 'upload_project']
 
 @needs_host
 def rsync_project(remote_dir, local_dir=None, exclude=(), delete=False,
-        default_opts='-pthrvz', extra_opts='', ssh_opts='', capture=False,
-        upload=True):
+        extra_opts='', ssh_opts='', capture=False, upload=True,
+        default_opts='-pthrvz'):
     """
     Synchronize a remote directory with the current project directory via rsync.
 
@@ -64,8 +64,6 @@ def rsync_project(remote_dir, local_dir=None, exclude=(), delete=False,
     * ``delete``: a boolean controlling whether ``rsync``'s ``--delete`` option
       is used. If True, instructs ``rsync`` to remove remote files that no
       longer exist locally. Defaults to False.
-    * ``default_opts``: the default rsync options ``-pthrvz``, override if
-      desired.
     * ``extra_opts``: an optional, arbitrary string which you may use to pass
       custom arguments or options to ``rsync``.
     * ``ssh_opts``: Like ``extra_opts`` but specifically for the SSH options
@@ -73,6 +71,8 @@ def rsync_project(remote_dir, local_dir=None, exclude=(), delete=False,
     * ``capture``: Sent directly into an inner `~fabric.operations.local` call.
     * ``upload``: a boolean controlling whether file synchronization is
       performed up or downstream. Upstream by default.
+    * ``default_opts``: the default rsync options ``-pthrvz``, override if
+      desired.
 
     Furthermore, this function transparently honors Fabric's port and SSH key
     settings. Calling this function when the current host string contains a
@@ -89,7 +89,7 @@ def rsync_project(remote_dir, local_dir=None, exclude=(), delete=False,
         The ``ssh_opts`` keyword argument.
     .. versionadded:: 1.4.1
         The ``capture`` keyword argument.
-    .. versionadded:: 1.6.2
+    .. versionadded:: 1.7.1
         The ``default_opts`` keyword argument.
 
     """


### PR DESCRIPTION
Previously there was no way to remove any of the predefined rsync options. This
change allows them to be modified via a keyword argument.

This does seem to make the extra_opts argument slightly redundant. I could remove it, but there would be backwards incompatibilities.

I also don't understand why the full call signature (all args) doesn't render in the Sphinx docs for rsync_project. The docs and usage would be clearer if the call signature didn't revert to:

fabric.contrib.project.rsync_project(_args, *_kwargs)

Instead rendering as:

fabric.contrib.project.rsync_project(remote_dir, local_dir=None, exclude=(), delete=False,
        default_opts='-pthrvz', extra_opts='', ssh_opts='', capture=False,
        upload=True)
