### PR TITLE
Tweaking template_dir before apply_lcwd is called on a None object.

### DIFF
--- a/fabric/contrib/files.py
+++ b/fabric/contrib/files.py
@@ -98,9 +98,10 @@ def upload_template(filename, destination, context=None, use_jinja=False,
     text = None
     if use_jinja:
         try:
+            template_dir = template_dir or '.'
             template_dir = apply_lcwd(template_dir, env)
             from jinja2 import Environment, FileSystemLoader
-            jenv = Environment(loader=FileSystemLoader(template_dir or '.'))
+            jenv = Environment(loader=FileSystemLoader(template_dir))
             text = jenv.get_template(filename).render(**context or {})
         except ImportError:
             import traceback


### PR DESCRIPTION
Issue #902

When calling `upload_template` with use_jinja=True and leaving template_dir=None, `apply_lcwd` is called with None
https://github.com/fabric/fabric/blob/master/fabric/contrib/files.py#L101

which calls `os.path.isabs(None)`
https://github.com/fabric/fabric/blob/master/fabric/utils.py#L356

which raises:

```
Python 2.7.2 (default, Oct 11 2012, 20:14:37)
[GCC 4.2.1 Compatible Apple Clang 4.0 (tags/Apple/clang-418.0.60)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from os.path import isabs
>>> isabs(None)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/posixpath.py", line 53, in isabs
    return s.startswith('/')
AttributeError: 'NoneType' object has no attribute 'startswith'
>>>
```
