### PR TITLE
added test for links

### DIFF
--- a/fabric/contrib/files.py
+++ b/fabric/contrib/files.py
@@ -36,6 +36,23 @@ def exists(path, use_sudo=False, verbose=False):
         return not func(cmd).failed
 
 
+def is_link(path, use_sudo=False, verbose=False):
+    """
+    Return True if the given path is a symlink on current remote host.
+
+    If ``use_sudo`` is True, will use `sudo` instead of `run`.
+
+    `is_link` will, by default, hide all output.
+    """
+    func = use_sudo and sudo or run
+    cmd = 'test -L "$(echo %s)"' % path
+    if verbose:
+        with settings(warn_only=True):
+            return not func(cmd).failed
+    with settings(hide('everything'), warn_only=True):
+        return not func(cmd).failed
+
+
 def first(*args, **kwargs):
     """
     Given one or more file paths, returns first one found, or None if none


### PR DESCRIPTION
This allows fabric to test if a file exists via symlink since a standard exists will not return the proper result.

Makes useful addition to test if a remote directory is a symlink or not, helps expand on "exists" method to give a broader scope for checking files and paths.

The "e" flag does not apply to links soft or hard.
