### PR TITLE
modify : colors auth version

### DIFF
--- a/fabric/auth.py
+++ b/fabric/auth.py
@@ -1,17 +1,15 @@
 """
 Common authentication subroutines. Primarily for internal use.
 """
+import state
+import network
 
 
 def get_password(user, host, port):
-    from fabric.state import env
-    from fabric.network import join_host_strings
-    host_string = join_host_strings(user, host, port)
-    return env.passwords.get(host_string, env.password)
+    host_string = network.join_host_strings(user, host, port)
+    return state.env.passwords.get(host_string, state.env.password)
 
 
 def set_password(user, host, port, password):
-    from fabric.state import env
-    from fabric.network import join_host_strings
-    host_string = join_host_strings(user, host, port)
-    env.password = env.passwords[host_string] = password
+    host_string = network.join_host_strings(user, host, port)
+    state.env.password = state.env.passwords[host_string] = password

--- a/fabric/colors.py
+++ b/fabric/colors.py
@@ -28,10 +28,8 @@ version of the original color on most terminals.
 def _wrap_with(code):
 
     def inner(text, bold=False):
-        c = code
-        if bold:
-            c = "1;%s" % c
-        return "\033[%sm%s\033[0m" % (c, text)
+        c = 1 if bold else 0
+        return "\033[%s;%sm%s\033[0m" % (c, code, text)
     return inner
 
 red = _wrap_with('31')

--- a/fabric/version.py
+++ b/fabric/version.py
@@ -25,7 +25,7 @@ def git_sha():
     # OSError occurs on Unix-derived platforms lacking Popen's configured shell
     # default, /bin/sh. E.g. Android.
     except OSError:
-        return None
+        return ""
 
 
 def get_version(form='short'):
@@ -54,7 +54,7 @@ def get_version(form='short'):
     type_num = VERSION[4]
     firsts = "".join([x[0] for x in type_.split()])
     sha = git_sha()
-    sha1 = (" (%s)" % sha) if sha else ""
+    sha1 = (" (%s)" % sha)
 
     # Branch
     versions['branch'] = branch


### PR DESCRIPTION
1. In auth.py .I think that since the two functions use the 'env' and 'join_host_strings', can be taken out of the module
2. In colors.py. In fact the bold can  use:  0:%s and 1:%s defined
3. In version.py.  when you use 'get_version', no longer need to determine that variable 'sha' results, you can return an exception when it is defined as ""
