### PR TITLE
Better assert message + cleanup in /tmp

### DIFF
--- a/integration/test_contrib.py
+++ b/integration/test_contrib.py
@@ -61,12 +61,21 @@ class TestTildeExpansion(Integration):
 
 
 class TestIsLink(Integration):
+    def setup(self):
+        self.created = []
+
+    def teardown(self):
+        super(TestIsLink, self).teardown()
+        for created in self.created:
+            os.unlink(created)
     # TODO: add more of these. meh.
     def test_is_link_is_true_on_symlink(self):
+        self.created.append("/tmp/bar")
         run("ln -s /tmp/foo /tmp/bar")
         assert files.is_link('/tmp/bar')
 
     def test_is_link_is_false_on_non_link(self):
+        self.created.append("/tmp/biz")
         run("touch /tmp/biz")
         assert not files.is_link('/tmp/biz')
 

--- a/integration/test_operations.py
+++ b/integration/test_operations.py
@@ -8,7 +8,8 @@ from utils import Integration
 
 
 def assert_mode(path, mode):
-    assert run("stat -c \"%%a\" %s" % path).stdout == mode
+    result = run("stat -c \"%%a\" %s" % path).stdout
+    assert result == mode, "Was expecting \""+mode+"\" got \""+result+"\""
 
 
 class TestOperations(Integration):
@@ -31,7 +32,8 @@ class TestOperations(Integration):
     def test_no_trailing_space_in_shell_path_in_run(self):
         put(StringIO("#!/bin/bash\necho hi"), "%s/myapp" % self.dirpath, mode="0755")
         with path(self.dirpath):
-            assert run('myapp').stdout == 'hi'
+            result = run('myapp').stdout
+            assert result == 'hi', "Was expecting \"hi\" got \""+result+"\""
 
     def test_string_put_mode_arg_doesnt_error(self):
         put(StringIO("#!/bin/bash\necho hi"), self.filepath, mode="0755")


### PR DESCRIPTION
TestOperations did not have asster message that could give a hint
 on what went wrong.

TestIsLink did not clean up after itself.
