### PR TITLE
Account for the fact that some file-like objects may not have a isatty() method

### DIFF
--- a/fabric/context_managers.py
+++ b/fabric/context_managers.py
@@ -41,6 +41,7 @@ import select
 from fabric.thread_handling import ThreadHandler
 from fabric.state import output, win32, connections, env
 from fabric import state
+from fabric.utils import isatty
 
 if not win32:
     import termios
@@ -429,7 +430,7 @@ def char_buffered(pipe):
 
     Only applies on Unix-based systems; on Windows this is a no-op.
     """
-    if win32 or not pipe.isatty():
+    if win32 or not isatty(pipe):
         yield
     else:
         old_settings = termios.tcgetattr(pipe)

--- a/fabric/utils.py
+++ b/fabric/utils.py
@@ -7,6 +7,18 @@ import sys
 import textwrap
 from traceback import format_exc
 
+
+def isatty(stream):
+    """Check if a stream is a tty.
+
+    Not all file-like objects implement the `isatty` method.
+    """
+    fn = getattr(stream, 'isatty', None)
+    if fn is None:
+        return False
+    return fn()
+
+
 def abort(msg):
     """
     Abort execution, print ``msg`` to stderr and exit with error status (1.)
@@ -264,7 +276,7 @@ def _pty_size():
         import struct
 
     rows, cols = 24, 80
-    if not win32 and sys.stdout.isatty():
+    if not win32 and isatty(sys.stdout):
         # We want two short unsigned integers (rows, cols)
         fmt = 'HH'
         # Create an empty (zeroed) buffer for ioctl to map onto. Yay for C!


### PR DESCRIPTION
This patch is inspired from that of #1019 and addresses a similar issue.

In my case, the issue I'm facing is that the pipe doesn't have an `isatty()` method when running the `fabric.contrib.files.sed` command on an Ubuntu 12.04.3 machine:

```
Traceback (most recent call last):
  File "/home/vagrant/.virtualenvs/myproject/local/lib/python2.7/site-packages/celery/app/trace.py", line 218, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/home/vagrant/.virtualenvs/myproject/local/lib/python2.7/site-packages/celery/app/trace.py", line 396, in __protected_call__
    return self.run(*args, **kwargs)
  File "/vagrant/myproject/myapp/tasks.py", line 35, in mytask
    sed('/etc/network/interfaces', old_ip, new_ip, use_sudo=True, )
  File "/home/vagrant/.virtualenvs/myproject/local/lib/python2.7/site-packages/fabric/contrib/files.py", line 204, in sed
    platform = run("uname")
  File "/home/vagrant/.virtualenvs/myproject/local/lib/python2.7/site-packages/fabric/network.py", line 578, in host_prompting_wrapper
    return func(*args, **kwargs)
  File "/home/vagrant/.virtualenvs/myproject/local/lib/python2.7/site-packages/fabric/operations.py", line 1042, in run
    shell_escape=shell_escape)
  File "/home/vagrant/.virtualenvs/myproject/local/lib/python2.7/site-packages/fabric/operations.py", line 911, in _run_command
    stderr=stderr, timeout=timeout)
  File "/home/vagrant/.virtualenvs/myproject/local/lib/python2.7/site-packages/fabric/operations.py", line 737, in _execute
    with char_buffered(sys.stdin):
  File "/usr/lib/python2.7/contextlib.py", line 17, in __enter__
    return self.gen.next()
  File "/home/vagrant/.virtualenvs/myproject/local/lib/python2.7/site-packages/fabric/context_managers.py", line 432, in char_buffered
    if win32 or not pipe.isatty():
AttributeError: '_fileobject' object has no attribute 'isatty'
```
