### PR TITLE
bugfix when use osx "no such option: --with-color"

### DIFF
--- a/fabfile/__init__.py
+++ b/fabfile/__init__.py
@@ -4,9 +4,11 @@ Fabric's own fabfile.
 
 from __future__ import with_statement
 
+import platform
+
 import nose
 
-from fabric.api import abort, local, task
+from fabric.api import local, task
 
 import tag
 from utils import msg
@@ -21,8 +23,9 @@ def test(args=None):
     """
     # Default to explicitly targeting the 'tests' folder, but only if nothing
     # is being overridden.
-    tests = "" if args else " tests"
-    default_args = "-sv --with-doctest --nologcapture --with-color %s" % tests
+    default_args = "-sv --with-doctest --nologcapture"
+    if platform.system() != 'Darwin':
+        default_args += " --with-color"
     default_args += (" " + args) if args else ""
     nose.core.run_exit(argv=[''] + default_args.split())
 


### PR DESCRIPTION
When i want to test fab with `fab test` on OSX 18.5,  display this:

```
$cd fabric
Usage: fab [options]

fab: error: no such option: --with-color
```

But on centos and ubuntu it's works. fab docsbut i do not kown why nosetests has not this option , so i think when osx, i do not add '--with-color'


The travis-ci error looks like a sphinx error.