### PR TITLE
README.rst specifies that the fabfile should be saved as fabfile.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,7 @@ complete "fabfile" containing a single task::
     def host_type():
         run('uname -s')
 
+Save it as ``fabfile.py``.
 Once a task is defined, it may be run on one or more servers, like so::
 
     $ fab -H localhost,linuxbox host_type


### PR DESCRIPTION
The README file fails to mention that the fabfile must be saved with the same `fabfile.py` for the next command to succeed.
This means that the new visitor who tries to execute the very first example will see it fail. On the contrary, the first tutorial mentions the name the fabfile must have.
In alternative, the line

```
$ fab -H localhost,linuxbox host_type
```

should include a `-f` option, which would ruin the simplicity of the example.
