### PR TITLE
Fix typo on ssh.ProxyCommand

### DIFF
--- a/fabric/network.py
+++ b/fabric/network.py
@@ -96,7 +96,7 @@ def get_gateway(host, port, cache, replace=False):
         # within that method.)
         sock = direct_tcpip(dict.__getitem__(cache, gateway), host, port)
     elif proxy_command:
-        sock = ssh.proxycommand(proxy_command)
+        sock = ssh.ProxyCommand(proxy_command)
     return sock
 
 


### PR DESCRIPTION
On fabric 1.8.1 we got `AttributeError: 'module' object has no attribute 'proxycommand' error` by the typo.

```
fab test
[biiwork] Executing task 'test'
[biiwork] run: echo 'Done test.'
Traceback (most recent call last):
.../Python/fabric/fabric/network.py", line 99, in get_gateway
    sock = ssh.proxycommand(proxy_command)
AttributeError: 'module' object has no attribute 'proxycommand'
```

This patch fixed it:

```
fab test
[biiwork] Executing task 'test'
[biiwork] run: echo 'Done test.'
[biiwork] out: Done test.
```
