### PR TITLE
Adding task contrib.files.test_file wrapping the `test` Unix command (and a bit more)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,7 @@
 Changelog
 =========
 
-* :feature:`?` Added `contrib.files.test_file <.test_file>` wrapping the `test`
+* :feature:`1047` Added `contrib.files.test_file <.test_file>` wrapping the `test`
   Unix command for testing files, and the more specific tasks
   `contrib.files.is_readable <.is_readable>`, `contrib.files.is_writable <.is_writable>`
   and `contrib.files.is_executable <.is_executable>`.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,11 @@
 Changelog
 =========
 
+* :feature:`?` Added `contrib.files.test_file <.test_file>` wrapping the `test`
+  Unix command for testing files, and the more specific tasks
+  `contrib.files.is_readable <.is_readable>`, `contrib.files.is_writable <.is_writable>`
+  and `contrib.files.is_executable <.is_executable>`.
+  Thanks to Alberto Scotto aka `@alb-i986` for the patch.
 * :release:`1.8.1 <2013-12-24>`
 * :release:`1.7.1 <2013-12-24>`
 * :release:`1.6.4 <2013-12-24>` 956, 957

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,8 +6,10 @@ Changelog
 
 * :feature:`1047` Added `contrib.files.test_file <.test_file>` wrapping the `test`
   Unix command for testing files, and the more specific tasks
-  `contrib.files.is_readable <.is_readable>`, `contrib.files.is_writable <.is_writable>`
-  and `contrib.files.is_executable <.is_executable>`.
+  `contrib.files.is_readable <.is_readable>`,
+  `contrib.files.is_writable <.is_writable>`,
+  `contrib.files.is_executable <.is_executable>`,
+  `contrib.files.is_dir <.is_dir>`, `contrib.files.is_file <.is_file>`.
   Thanks to Alberto Scotto aka `@alb-i986` for the patch.
 * :release:`1.8.1 <2013-12-24>`
 * :release:`1.7.1 <2013-12-24>`

--- a/fabric/contrib/files.py
+++ b/fabric/contrib/files.py
@@ -89,15 +89,13 @@ def test_file(path, op, use_sudo=False, verbose=False):
     op_pattern = r'^[bcdefgGhkLOprsStuwx]$'
     if not re.search(op_pattern, op):
         raise ValueError("'%s' is not a valid operator for the 'test' Unix command" % op)
-    func = use_sudo and sudo or run
+    func = sudo if use_sudo else run
     cmd = 'test -%s %s' % (op, _expand_path(path))
-    # If verbose, run normally
-    if verbose:
-        with settings(warn_only=True):
-            return not func(cmd).failed
-    # Otherwise, be quiet
-    with settings(hide('everything'), warn_only=True):
-        return not func(cmd).failed
+    args, kwargs = [], {'warn_only': True}
+    if not verbose:
+        opts = [hide('everything')]
+    with settings(*args, **kwargs):
+        return func(cmd).succeeded
 
 
 def is_link(path, use_sudo=False, verbose=False):
@@ -108,13 +106,7 @@ def is_link(path, use_sudo=False, verbose=False):
 
     `.is_link` will, by default, hide all output. Give ``verbose=True`` to change this.
     """
-    func = sudo if use_sudo else run
-    cmd = 'test -L "$(echo %s)"' % path
-    args, kwargs = [], {'warn_only': True}
-    if not verbose:
-        opts = [hide('everything')]
-    with settings(*args, **kwargs):
-        return func(cmd).succeeded
+    return test_file(path, 'L', use_sudo, verbose)
 
 
 def first(*args, **kwargs):

--- a/fabric/contrib/files.py
+++ b/fabric/contrib/files.py
@@ -99,7 +99,8 @@ def test_file(path, op, use_sudo=False, verbose=False):
     # check that `op` is a valid unary operator for the `test` command
     op_pattern = r'^[bcdefgGhkLOprsStuwx]$'
     if not re.search(op_pattern, op):
-        raise ValueError("'%s' is not a valid operator for the 'test' Unix command" % op)
+        raise ValueError("'%s' is not a valid operator for the 'test' Unix command" % op +
+                        " (please refer to `man test`)")
     func = sudo if use_sudo else run
     cmd = 'test -%s %s' % (op, _expand_path(path))
     args, kwargs = [], {'warn_only': True}

--- a/fabric/contrib/files.py
+++ b/fabric/contrib/files.py
@@ -93,7 +93,7 @@ def test_file(path, op, use_sudo=False, verbose=False):
     cmd = 'test -%s %s' % (op, _expand_path(path))
     args, kwargs = [], {'warn_only': True}
     if not verbose:
-        args = [hide('everything')]
+        args += [hide('everything')]
     with settings(*args, **kwargs):
         return func(cmd).succeeded
 

--- a/fabric/contrib/files.py
+++ b/fabric/contrib/files.py
@@ -73,6 +73,17 @@ def is_executable(path, use_sudo=False, verbose=False):
     return test_file(path, 'x', use_sudo, verbose)
 
 
+def is_link(path, use_sudo=False, verbose=False):
+    """
+    Return True if the given path is a symlink on the current remote host.
+
+    If ``use_sudo`` is True, will use `.sudo` instead of `.run`.
+
+    `.is_link` will, by default, hide all output. Give ``verbose=True`` to change this.
+    """
+    return test_file(path, 'L', use_sudo, verbose)
+
+
 def test_file(path, op, use_sudo=False, verbose=False):
     """
     Wrapper task for the `test` Unix command, in the unary form for testing files.
@@ -96,17 +107,6 @@ def test_file(path, op, use_sudo=False, verbose=False):
         args += [hide('everything')]
     with settings(*args, **kwargs):
         return func(cmd).succeeded
-
-
-def is_link(path, use_sudo=False, verbose=False):
-    """
-    Return True if the given path is a symlink on the current remote host.
-
-    If ``use_sudo`` is True, will use `.sudo` instead of `.run`.
-
-    `.is_link` will, by default, hide all output. Give ``verbose=True`` to change this.
-    """
-    return test_file(path, 'L', use_sudo, verbose)
 
 
 def first(*args, **kwargs):

--- a/fabric/contrib/files.py
+++ b/fabric/contrib/files.py
@@ -57,6 +57,28 @@ def is_executable(path, use_sudo=False, verbose=False):
     return test_file(path, 'x', use_sudo, verbose)
 
 
+def is_dir(path, use_sudo=False, verbose=False):
+    """
+    Return True if given path exists and is a directory on the current remote
+    host.
+
+    For an explanation of the arguments ``use_sudo`` and ``verbose``
+    please refer to `test_file`.
+    """
+    return test_file(path, 'd', use_sudo, verbose)
+
+
+def is_file(path, use_sudo=False, verbose=False):
+    """
+    Return True if given path exists and is a regular file on the current remote
+    host.
+
+    For an explanation of the arguments ``use_sudo`` and ``verbose``
+    please refer to `test_file`.
+    """
+    return test_file(path, 'f', use_sudo, verbose)
+
+
 def is_link(path, use_sudo=False, verbose=False):
     """
     Return True if the given path is a symlink on the current remote host.

--- a/fabric/contrib/files.py
+++ b/fabric/contrib/files.py
@@ -25,8 +25,71 @@ def exists(path, use_sudo=False, verbose=False):
     avoid cluttering output. You may specify ``verbose=True`` to change this
     behavior.
     """
+    return test_file(path, 'e', use_sudo, verbose)
+
+
+def is_readable(path, use_sudo=False, verbose=False):
+    """
+    Return True if given path exists and read permission is granted 
+    to the current user on the current remote host.
+
+    If ``use_sudo`` is True, will use `sudo` instead of `run`.
+
+    `is_readable` will, by default, hide all output (including the run line, stdout,
+    stderr and any warning resulting from the file not being readable) in order to
+    avoid cluttering output. You may specify ``verbose=True`` to change this
+    behavior.
+    """
+    return test_file(path, 'r', use_sudo, verbose)
+
+
+def is_writable(path, use_sudo=False, verbose=False):
+    """
+    Return True if given path exists and write permission is granted
+    to the current user on the current remote host.
+
+    If ``use_sudo`` is True, will use `sudo` instead of `run`.
+
+    `is_writable` will, by default, hide all output (including the run line, stdout,
+    stderr and any warning resulting from the file not being writable) in order to
+    avoid cluttering output. You may specify ``verbose=True`` to change this
+    behavior.
+    """
+    return test_file(path, 'w', use_sudo, verbose)
+
+
+def is_executable(path, use_sudo=False, verbose=False):
+    """
+    Return True if given path exists and execute (or search) permission is granted
+    to the current user on the current remote host.
+
+    If ``use_sudo`` is True, will use `sudo` instead of `run`.
+
+    `is_executable` will, by default, hide all output (including the run line, stdout,
+    stderr and any warning resulting from the file not being executable) in order to
+    avoid cluttering output. You may specify ``verbose=True`` to change this
+    behavior.
+    """
+    return test_file(path, 'x', use_sudo, verbose)
+
+
+def test_file(path, op, use_sudo=False, verbose=False):
+    """
+    Wrapper for the Unix command `test`, in the unary form.
+    Return True if the test against the file passes on the current remote host.
+
+    If ``use_sudo`` is True, will use `sudo` instead of `run`.
+
+    `test_file` will, by default, hide all output (including the run line, stdout,
+    stderr and any warning resulting from the file not passing the test)
+    in order to avoid cluttering output. You may specify ``verbose=True``
+    to change this behavior.
+    """
+    op_pattern = r'^[bcdefgGhkLOprsStuwx]$'
+    if not re.search(op_pattern, op):
+        raise ValueError("'%s' is not a valid operator for the `test` command" % op)
     func = use_sudo and sudo or run
-    cmd = 'test -e %s' % _expand_path(path)
+    cmd = 'test -%s %s' % (op, _expand_path(path))
     # If verbose, run normally
     if verbose:
         with settings(warn_only=True):

--- a/fabric/contrib/files.py
+++ b/fabric/contrib/files.py
@@ -75,7 +75,7 @@ def is_executable(path, use_sudo=False, verbose=False):
 
 def test_file(path, op, use_sudo=False, verbose=False):
     """
-    Wrapper for the Unix command `test`, in the unary form.
+    Wrapper task for the `test` Unix command, in the unary form for testing files.
     Return True if the test against the file passes on the current remote host.
 
     If ``use_sudo`` is True, will use `sudo` instead of `run`.
@@ -85,9 +85,10 @@ def test_file(path, op, use_sudo=False, verbose=False):
     in order to avoid cluttering output. You may specify ``verbose=True``
     to change this behavior.
     """
+    # check that `op` is a valid unary operator for the `test` command
     op_pattern = r'^[bcdefgGhkLOprsStuwx]$'
     if not re.search(op_pattern, op):
-        raise ValueError("'%s' is not a valid operator for the `test` command" % op)
+        raise ValueError("'%s' is not a valid operator for the 'test' Unix command" % op)
     func = use_sudo and sudo or run
     cmd = 'test -%s %s' % (op, _expand_path(path))
     # If verbose, run normally

--- a/fabric/contrib/files.py
+++ b/fabric/contrib/files.py
@@ -93,7 +93,7 @@ def test_file(path, op, use_sudo=False, verbose=False):
     cmd = 'test -%s %s' % (op, _expand_path(path))
     args, kwargs = [], {'warn_only': True}
     if not verbose:
-        opts = [hide('everything')]
+        args = [hide('everything')]
     with settings(*args, **kwargs):
         return func(cmd).succeeded
 

--- a/fabric/contrib/files.py
+++ b/fabric/contrib/files.py
@@ -18,12 +18,8 @@ def exists(path, use_sudo=False, verbose=False):
     """
     Return True if given path exists on the current remote host.
 
-    If ``use_sudo`` is True, will use `sudo` instead of `run`.
-
-    `exists` will, by default, hide all output (including the run line, stdout,
-    stderr and any warning resulting from the file not existing) in order to
-    avoid cluttering output. You may specify ``verbose=True`` to change this
-    behavior.
+    For an explanation of the arguments ``use_sudo`` and ``verbose``
+    please refer to `test_file`.
     """
     return test_file(path, 'e', use_sudo, verbose)
 
@@ -33,12 +29,8 @@ def is_readable(path, use_sudo=False, verbose=False):
     Return True if given path exists and read permission is granted 
     to the current user on the current remote host.
 
-    If ``use_sudo`` is True, will use `sudo` instead of `run`.
-
-    `is_readable` will, by default, hide all output (including the run line, stdout,
-    stderr and any warning resulting from the file not being readable) in order to
-    avoid cluttering output. You may specify ``verbose=True`` to change this
-    behavior.
+    For an explanation of the arguments ``use_sudo`` and ``verbose``
+    please refer to `test_file`.
     """
     return test_file(path, 'r', use_sudo, verbose)
 
@@ -48,12 +40,8 @@ def is_writable(path, use_sudo=False, verbose=False):
     Return True if given path exists and write permission is granted
     to the current user on the current remote host.
 
-    If ``use_sudo`` is True, will use `sudo` instead of `run`.
-
-    `is_writable` will, by default, hide all output (including the run line, stdout,
-    stderr and any warning resulting from the file not being writable) in order to
-    avoid cluttering output. You may specify ``verbose=True`` to change this
-    behavior.
+    For an explanation of the arguments ``use_sudo`` and ``verbose``
+    please refer to `test_file`.
     """
     return test_file(path, 'w', use_sudo, verbose)
 
@@ -63,12 +51,8 @@ def is_executable(path, use_sudo=False, verbose=False):
     Return True if given path exists and execute (or search) permission is granted
     to the current user on the current remote host.
 
-    If ``use_sudo`` is True, will use `sudo` instead of `run`.
-
-    `is_executable` will, by default, hide all output (including the run line, stdout,
-    stderr and any warning resulting from the file not being executable) in order to
-    avoid cluttering output. You may specify ``verbose=True`` to change this
-    behavior.
+    For an explanation of the arguments ``use_sudo`` and ``verbose``
+    please refer to `test_file`.
     """
     return test_file(path, 'x', use_sudo, verbose)
 
@@ -77,17 +61,21 @@ def is_link(path, use_sudo=False, verbose=False):
     """
     Return True if the given path is a symlink on the current remote host.
 
-    If ``use_sudo`` is True, will use `.sudo` instead of `.run`.
-
-    `.is_link` will, by default, hide all output. Give ``verbose=True`` to change this.
+    For an explanation of the arguments ``use_sudo`` and ``verbose``
+    please refer to `test_file`.
     """
     return test_file(path, 'L', use_sudo, verbose)
 
 
 def test_file(path, op, use_sudo=False, verbose=False):
     """
-    Wrapper task for the `test` Unix command, in the unary form for testing files.
+    Task wrapping the `test` Unix command, specifically used for testing files.
     Return True if the test against the file passes on the current remote host.
+
+    ``op`` is a unary operator for testing files, accepted by the `test` command.
+    The allowed values are `b`, `c`, `d`, `e`, `f`, `g`, `G`, `h`, `k`, `L`, `O`,
+    `p`, `r`, `s`, `S`, `u`, `w`, `x`.
+    Refer to `man test` for a detailed explanation.
 
     If ``use_sudo`` is True, will use `sudo` instead of `run`.
 

--- a/fabric/contrib/files.py
+++ b/fabric/contrib/files.py
@@ -97,7 +97,7 @@ def test_file(path, op, use_sudo=False, verbose=False):
     to change this behavior.
     """
     # check that `op` is a valid unary operator for the `test` command
-    op_pattern = r'^[bcdefgGhkLOprsStuwx]$'
+    op_pattern = r'^[bcdefgGhkLOprsSuwx]$'
     if not re.search(op_pattern, op):
         raise ValueError("'%s' is not a valid operator for the 'test' Unix command" % op +
                         " (please refer to `man test`)")

--- a/integration/test_contrib.py
+++ b/integration/test_contrib.py
@@ -97,17 +97,41 @@ class TestFile(Integration):
         assert not files.is_dir(f)
         assert not files.test_file(f, 'd')
 
-    def test_is_writable_is_true_on_w(self):
+    def test_is_writable_is_true_on_chmod200(self):
         f = run("mktemp /tmp/foofile.XXXXXX", stdout=False)
-        run("chmod 777 %s" % f)
+        run("chmod 200 %s" % f)
         assert files.is_writable(f)
         assert files.test_file(f,'w')
 
-    def test_is_writable_is_false_on_ro(self):
+    def test_is_writable_is_false_on_chmod400(self):
         f = run("mktemp /tmp/foofile.XXXXXX", stdout=False)
         run("chmod 400 %s" % f)
         assert not files.is_writable(f)
         assert not files.test_file(f,'w')
+
+    def test_is_executable_is_true_on_chmod100(self):
+        f = run("mktemp /tmp/foofile.XXXXXX", stdout=False)
+        run("chmod 100 %s" % f)
+        assert files.is_executable(f)
+        assert files.test_file(f,'x')
+
+    def test_is_executable_is_false_on_chmod400(self):
+        f = run("mktemp /tmp/foofile.XXXXXX", stdout=False)
+        run("chmod 400 %s" % f)
+        assert not files.is_executable(f)
+        assert not files.test_file(f,'x')
+
+    def test_is_readable_is_true_on_chmod400(self):
+        f = run("mktemp /tmp/foofile.XXXXXX", stdout=False)
+        run("chmod 400 %s" % f)
+        assert files.is_readable(f)
+        assert files.test_file(f,'r')
+
+    def test_is_readable_is_false_on_chmod200(self):
+        f = run("mktemp /tmp/foofile.XXXXXX", stdout=False)
+        run("chmod 200 %s" % f)
+        assert not files.is_readable(f)
+        assert not files.test_file(f,'r')
 
 
 rsync_sources = (

--- a/integration/test_contrib.py
+++ b/integration/test_contrib.py
@@ -87,8 +87,8 @@ class TestFile(Integration):
         l = '/tmp/foolink'
         run("rm -rf %s" % l)
         run("ln -s %s %s" % (f, l))
-        assert not files.is_file(f)
-        assert not files.test_file(f, 'f')
+        assert not files.is_file(l)
+        assert not files.test_file(l, 'f')
 
     def test_is_dir_is_true_on_dir(self):
         d = run("mktemp -d /tmp/foodir.XXXXXX", stdout=False)

--- a/integration/test_contrib.py
+++ b/integration/test_contrib.py
@@ -60,8 +60,7 @@ class TestTildeExpansion(Integration):
             expect(target)
 
 
-class TestIsLink(Integration):
-    # TODO: add more of these. meh.
+class TestFile(Integration):
     def test_is_link_is_true_on_symlink(self):
         f = run("mktemp /tmp/foofile.XXXXXX", stdout=False)
         l = '/tmp/foolink'
@@ -75,8 +74,6 @@ class TestIsLink(Integration):
         assert not files.is_link(f)
         assert not files.test_file(f,'L')
 
-
-class TestFile(Integration):
     def test_is_file_is_true_on_regular(self):
         f = run("mktemp /tmp/foofile.XXXXXX", stdout=False)
         assert files.is_file(f)

--- a/integration/test_contrib.py
+++ b/integration/test_contrib.py
@@ -82,13 +82,10 @@ class TestFile(Integration):
         assert files.is_file(f)
         assert files.test_file(f,'f')
 
-    def test_is_file_is_false_on_non_regular(self):
-        f = run("mktemp /tmp/foofile.XXXXXX", stdout=False)
-        l = '/tmp/foolink'
-        run("rm -rf %s" % l)
-        run("ln -s %s %s" % (f, l))
-        assert not files.is_file(l)
-        assert not files.test_file(l, 'f')
+    def test_is_file_is_false_on_dir(self):
+        d = run("mktemp -d /tmp/foodir.XXXXXX", stdout=False)
+        assert not files.is_file(d)
+        assert not files.test_file(d, 'f')
 
     def test_is_dir_is_true_on_dir(self):
         d = run("mktemp -d /tmp/foodir.XXXXXX", stdout=False)

--- a/integration/test_contrib.py
+++ b/integration/test_contrib.py
@@ -63,12 +63,54 @@ class TestTildeExpansion(Integration):
 class TestIsLink(Integration):
     # TODO: add more of these. meh.
     def test_is_link_is_true_on_symlink(self):
-        run("ln -s /tmp/foo /tmp/bar")
-        assert files.is_link('/tmp/bar')
+        f = run("mktemp /tmp/foofile.XXXXXX", stdout=False)
+        l = '/tmp/foolink'
+        run("rm -rf %s" % l)
+        run("ln -s %s %s" % (f,l))
+        assert files.is_link(l)
+        assert files.test_file(l,'L')
 
     def test_is_link_is_false_on_non_link(self):
-        run("touch /tmp/biz")
-        assert not files.is_link('/tmp/biz')
+        f = run("mktemp /tmp/foofile.XXXXXX", stdout=False)
+        assert not files.is_link(f)
+        assert not files.test_file(f,'L')
+
+
+class TestFile(Integration):
+    def test_is_file_is_true_on_regular(self):
+        f = run("mktemp /tmp/foofile.XXXXXX", stdout=False)
+        assert files.is_file(f)
+        assert files.test_file(f,'f')
+
+    def test_is_file_is_false_on_non_regular(self):
+        f = run("mktemp /tmp/foofile.XXXXXX", stdout=False)
+        l = '/tmp/foolink'
+        run("rm -rf %s" % l)
+        run("ln -s %s %s" % (f, l))
+        assert not files.is_file(f)
+        assert not files.test_file(f, 'f')
+
+    def test_is_dir_is_true_on_dir(self):
+        d = run("mktemp -d /tmp/foodir.XXXXXX", stdout=False)
+        assert files.is_dir(d)
+        assert files.test_file(d,'d')
+
+    def test_is_dir_is_false_on_non_dir(self):
+        f = run("mktemp /tmp/foofile.XXXXXX", stdout=False)
+        assert not files.is_dir(f)
+        assert not files.test_file(f, 'd')
+
+    def test_is_writable_is_true_on_w(self):
+        f = run("mktemp /tmp/foofile.XXXXXX", stdout=False)
+        run("chmod 777 %s" % f)
+        assert files.is_writable(f)
+        assert files.test_file(f,'w')
+
+    def test_is_writable_is_false_on_ro(self):
+        f = run("mktemp /tmp/foofile.XXXXXX", stdout=False)
+        run("chmod 400 %s" % f)
+        assert not files.is_writable(f)
+        assert not files.test_file(f,'w')
 
 
 rsync_sources = (


### PR DESCRIPTION
With `test_file` Fabric finally features a generic task for testing properties on a file, supporting any (unary) tests that the Unix `test` command supports (*).

Moreover:
- refactoring `is_link` and `exists`: now they just pass on to `test_file`
- adding a few common test tasks: `is_readable`, `is_writable`, `is_executable`, `is_file`, `is_dir`.

Patch made by leveraging code from pulls #925 (refactorings to `is_link` by @bitprophet) and #928 (a bug fix to the #925 refactorings), so thanks @bitprophet and @apbarrero.

Soon I am going to add some integration tests.

Hope everything's OK.
Let me know

AS

(*) Not sure if the unary operators of `test` are universal to every platform for which Fabric is built. If it isn't so, it's possible to restrict the allowed operators through the `op_pattern` variable (now holding [bcdefgGhkLOprsSuwx], filled up with what I found in `man test` on my Debian PC)
