### PR TITLE
is_link should respect verbose=False

### DIFF
--- a/fabric/contrib/files.py
+++ b/fabric/contrib/files.py
@@ -48,7 +48,7 @@ def is_link(path, use_sudo=False, verbose=False):
     cmd = 'test -L "$(echo %s)"' % path
     args, kwargs = [], {'warn_only': True}
     if not verbose:
-        opts = [hide('everything')]
+        args = [hide('everything')]
     with settings(*args, **kwargs):
         return func(cmd).succeeded
 


### PR DESCRIPTION
fixed a variable typo preventing is_link from respecting verbose=False
