### PR TITLE
support link-local IPv6 host addresses

### DIFF
--- a/fabric/network.py
+++ b/fabric/network.py
@@ -33,7 +33,8 @@ Please make sure all dependencies are installed and importable.
     sys.exit(1)
 
 
-ipv6_regex = re.compile('^\[?(?P<host>[0-9A-Fa-f:]+)\]?(:(?P<port>\d+))?$')
+ipv6_regex = re.compile(
+    '^\[?(?P<host>[0-9A-Fa-f:]+(?:%[a-z]+\d+)?)\]?(:(?P<port>\d+))?$')
 
 
 def direct_tcpip(client, host, port):


### PR DESCRIPTION
SSHing to a link-local IPv6 address requires the following syntax:

```
ssh fe80::74f8:52ff:fe00:4%eth1
```

This change adds "%interface" as part of IPv6 host regex in fabric.

```
[fe80::74f8:52ff:fe00:4%eth1] Executing task 'foo'
[fe80::74f8:52ff:fe00:4%eth1] put: test1.txt -> /tmp/test1.txt
```
