### PR TITLE
tiny change, fix incorrect reference to SSH config variable "ClientAlive...

### DIFF
--- a/docs/usage/env.rst
+++ b/docs/usage/env.rst
@@ -393,7 +393,7 @@ The global host list used when composing per-task host lists.
 **Default:** ``0`` (i.e. no keepalive)
 
 An integer specifying an SSH keepalive interval to use; basically maps to the
-SSH config option ``ClientAliveInterval``. Useful if you find connections are
+SSH config option ``ServerAliveInterval``. Useful if you find connections are
 timing out due to meddlesome network hardware or what have you.
 
 .. seealso:: :option:`--keepalive`


### PR DESCRIPTION
...Interval"

Confusingly, the SSH client's keepalive parameter is "ServerAliveInterval" (ie, how often to check the server is alive), whereas "ClientAliveInterval" is something you would set server-side.

https://unix.stackexchange.com/questions/3026/what-do-the-options-serveraliveinterval-and-clientaliveinterval-in-sshd-conf

http://unixhelp.ed.ac.uk/CGI/man-cgi?ssh_config+5

http://unixhelp.ed.ac.uk/CGI/man-cgi?sshd_config+5
