### PR TITLE
Added 'given_command' to local() 'out'

### DIFF
--- a/fabric/operations.py
+++ b/fabric/operations.py
@@ -1175,6 +1175,7 @@ def local(command, capture=False, shell=None):
     # Handle error condition (deal with stdout being None, too)
     out = _AttributeString(stdout.strip() if stdout else "")
     err = _AttributeString(stderr.strip() if stderr else "")
+    out.command = given_command
     out.failed = False
     out.return_code = p.returncode
     out.stderr = err


### PR DESCRIPTION
This makes adds the 'command' attribute to local()'s return, as
in run() and sudo() to make the initial command accessible after
execution.
