### PR TITLE
Removed duplicate/typo changelog entry for out-of-order 1.7.2

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,7 +7,6 @@ Changelog
 * :feature:`1082` Add ``pty`` passthrough kwarg to
   `~fabric.contrib.files.upload_template`.
 * :release:`1.8.2 <2014-02-14>`
-* :release:`1.7.2 <2014-02-14>`
 * :bug:`955` Quote directories created as part of ``put``'s recursive directory
   uploads when ``use_sudo=True`` so directories with shell meta-characters
   (such as spaces) work correctly. Thanks to John Harris for the catch.


### PR DESCRIPTION
Just a small fix for the ChangeLog.
