### PR TITLE
Set the reboot command

### DIFF
--- a/fabric/operations.py
+++ b/fabric/operations.py
@@ -1188,7 +1188,7 @@ def local(command, capture=False, shell=None):
 
 
 @needs_host
-def reboot(wait=120):
+def reboot(wait=120, reboot_command = 'reboot'):
     """
     Reboot the remote system.
 
@@ -1225,7 +1225,7 @@ def reboot(wait=120):
         timeout=timeout,
         connection_attempts=attempts
     ):
-        sudo('reboot')
+        sudo(reboot_command)
         # Try to make sure we don't slip in before pre-reboot lockdown
         time.sleep(5)
         # This is actually an internal-ish API call, but users can simply drop


### PR DESCRIPTION
This update makes it possible to set the reboot command. In our case when we use molly-guard to prevent accidental reboots we need to use /sbin/reboot and not reboot.
