### PR TITLE
Fix bug in env.use_shell docs

### DIFF
--- a/sites/docs/usage/env.rst
+++ b/sites/docs/usage/env.rst
@@ -787,7 +787,7 @@ Network connection timeout, in seconds.
 
 **Default:** ``True``
 
-Global setting which acts like the ``use_shell`` argument to
+Global setting which acts like the ``shell`` argument to
 `~fabric.operations.run`/`~fabric.operations.sudo`: if it is set to ``False``,
 operations will not wrap executed commands in ``env.shell``.
 


### PR DESCRIPTION
`run`/`sudo` functions have `shell` argument, not `use_shell`. Probably it should be called `use_shell` but due to backwards compatibility I suggest to change only docs.
