### PR TITLE
Fixes #938, effective roles env var

### DIFF
--- a/fabric/state.py
+++ b/fabric/state.py
@@ -315,6 +315,7 @@ env = _AttributeDict({
     'default_port': default_port,
     'eagerly_disconnect': False,
     'echo_stdin': True,
+    'effective_roles': [],
     'exclude_hosts': [],
     'gateway': None,
     'host': None,

--- a/sites/docs/usage/env.rst
+++ b/sites/docs/usage/env.rst
@@ -293,6 +293,17 @@ limits on per-process open files, or network hardware.
     throughout your output, instead of at the end. This may be improved in
     future releases.
 
+.. _effective_roles:
+
+``effective_roles``
+-------------------
+
+**Default:** ``[]``
+
+Set by ``fab`` to the roles list of the currently executing command. For
+informational purposes only.
+
+.. seealso:: :doc:`execution`
 
 .. _exclude-hosts:
 

--- a/sites/www/changelog.rst
+++ b/sites/www/changelog.rst
@@ -2,6 +2,9 @@
 Changelog
 =========
 
+* :feature:`938` Add an env var :ref:`env.effective_roles <effective_roles>`
+  specifying roles used in the currently executing command. Thanks to
+  Piotr Betkier for the patch.
 * :support:`1105 backported` Enhance ``setup.py`` to allow Paramiko 1.13+ under
   Python 2.6+. Thanks to to ``@Arfrever`` for catch & patch.
 * :release:`1.8.3 <2014-03-21>`


### PR DESCRIPTION
This PR fixes #938 by adding `effective_roles` env var which contains the roles used for the currently executing command.
