### PR TITLE
Update docs - env.all_hosts default value

### DIFF
--- a/sites/docs/usage/env.rst
+++ b/sites/docs/usage/env.rst
@@ -146,7 +146,7 @@ when unforeseen circumstances arise.
 ``all_hosts``
 -------------
 
-**Default:** ``None``
+**Default:** ``[]``
 
 Set by ``fab`` to the full host list for the currently executing command. For
 informational purposes only.


### PR DESCRIPTION
Default value for env.all_hosts is [], not None.
