### PR TITLE
Fix to respect 'template_dir' for non Jinja2 templates (#852)

### DIFF
--- a/fabric/contrib/files.py
+++ b/fabric/contrib/files.py
@@ -80,7 +80,9 @@ def upload_template(filename, destination, context=None, use_jinja=False,
 
     Alternately, if ``use_jinja`` is set to True and you have the Jinja2
     templating library available, Jinja will be used to render the template
-    instead. Templates will be loaded from the invoking user's current working
+    instead.
+
+    Templates will be loaded from the invoking user's current working
     directory by default, or from ``template_dir`` if given.
 
     The resulting rendered file will be uploaded to the remote file path
@@ -138,7 +140,10 @@ def upload_template(filename, destination, context=None, use_jinja=False,
             tb = traceback.format_exc()
             abort(tb + "\nUnable to import Jinja2 -- see above.")
     else:
+        if template_dir:
+            filename = os.path.join(template_dir, filename)
         filename = apply_lcwd(filename, env)
+
         with open(os.path.expanduser(filename)) as inputfile:
             text = inputfile.read()
         if context:

--- a/sites/www/changelog.rst
+++ b/sites/www/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :bug:`852` Fix to respect 'template_dir' for non Jinja2 templates. Thanks to
+  Adam Kowalski for the patch.
 * :support:`1105 backported` Enhance ``setup.py`` to allow Paramiko 1.13+ under
   Python 2.6+. Thanks to to ``@Arfrever`` for catch & patch.
 * :release:`1.8.3 <2014-03-21>`

--- a/tests/test_contrib.py
+++ b/tests/test_contrib.py
@@ -38,6 +38,24 @@ class TestContrib(FabricTest):
             get(remote, local)
         eq_contents(local, var)
 
+    @server()
+    def test_upload_template_handles_template_dir(self):
+        """
+        upload_template() should work OK with template dir
+        """
+
+        template = self.mkfile('template.txt', '%(varname)s')
+        template_dir = os.path.dirname(template)
+
+        local = self.path('result.txt')
+        remote = '/configfile.txt'
+        var = 'foobar'
+        with hide('everything'):
+            upload_template(template, remote, {'varname': var}, template_dir=template_dir)
+            get(remote, local)
+        eq_contents(local, var)
+
+
     @server(responses={
         'egrep "text" "/file.txt"': (
             "sudo: unable to resolve host fabric",


### PR DESCRIPTION
Fixes: #858 and #852
