### PR TITLE
Treat paths that begin with tilde "~" as absolute paths

### DIFF
--- a/fabric/context_managers.py
+++ b/fabric/context_managers.py
@@ -329,7 +329,7 @@ def lcd(path):
 
 def _change_cwd(which, path):
     path = path.replace(' ', '\ ')
-    if state.env.get(which) and not path.startswith('/'):
+    if state.env.get(which) and not path.startswith('/') and not path.startswith('~'):
         new_cwd = state.env.get(which) + '/' + path
     else:
         new_cwd = path

--- a/sites/www/changelog.rst
+++ b/sites/www/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :bug:`898` Treat paths that begin with tilde "~" as absolute paths instead of relative.
+  Thanks to Alex Plugaru for the patch and Dan Craig for the suggestion.
 * :support:`1105 backported` Enhance ``setup.py`` to allow Paramiko 1.13+ under
   Python 2.6+. Thanks to to ``@Arfrever`` for catch & patch.
 * :release:`1.8.3 <2014-03-21>`


### PR DESCRIPTION
Fixes #898
