### PR TITLE
Reflect the fact that paramiko is py3 compatible

### DIFF
--- a/sites/www/roadmap.rst
+++ b/sites/www/roadmap.rst
@@ -55,9 +55,6 @@ tool, and plan to:
     * Any other core overhauls difficult to do in a backwards compatible
       fashion.
     * Test-driven development (Invoke does this as well.)
-    * Requires Paramiko to become Python 3 compatible - one of the major
-      hurdles to overcome. See `Paramiko #16
-      <https://github.com/paramiko/paramiko/issues/16>`_.
 
 * Spin off ``fabric.contrib.*`` into a standalone "super-Fabric" (as in, "above Fabric") library, `Patchwork <https://github.com/fabric/patchwork>`_.
 


### PR DESCRIPTION
Since version 1.13.0 paramiko has python 3 support, update the documentation to reflect that.
