### PR TITLE
Fix `isdir` checking inside of SFTP class

### DIFF
--- a/fabric/sftp.py
+++ b/fabric/sftp.py
@@ -36,7 +36,7 @@ class SFTP(object):
 
     def isdir(self, path):
         try:
-            return stat.S_ISDIR(self.ftp.lstat(path).st_mode)
+            return stat.S_ISDIR(self.ftp.stat(path).st_mode)
         except IOError:
             return False
 


### PR DESCRIPTION
We have to use `stat` instead of `lstat` inside `isdir` method, since the first one returns `True` even for symlinks to folders.

The fix is very important when we need to download some folder that contains a symlink to another one.
