### PR TITLE
Provide correct path to the installing.rst documentation

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,2 +1,2 @@
 For installation help, please see http://fabfile.org/ or (if using a source
-checkout) sites/www/installation.rst.
+checkout) sites/www/installing.rst.


### PR DESCRIPTION
This pull requests fixes the location to the installing.rst documentation
