### PR TITLE
Don't pin Jinja2 in Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,7 @@ install:
   - pip install -e .
   # Deal with issue on Travis builders re: multiprocessing.Queue :(
   - "sudo rm -rf /dev/shm && sudo ln -s /run/shm /dev/shm"
-  # Jinja2 for some tests, in a version that isn't broken on 2.5 :(
-  - 'pip install "jinja2<2.7"'
+  - "pip install jinja2"
 before_script:
   # Allow us to SSH passwordless to localhost
   - ssh-keygen -f ~/.ssh/id_rsa -N ""


### PR DESCRIPTION
Since we're not even running the tests against Python 2.5, I see no reason to force an older version of Jinja2.
