### PR TITLE
allow env.shell to be a python-format-string

### DIFF
--- a/fabric/operations.py
+++ b/fabric/operations.py
@@ -624,11 +624,12 @@ def _shell_wrap(command, shell_escape, shell=True, sudo_prefix=None):
         shell = env.shell + " "
         if shell_escape:
             command = _shell_escape(command)
-        command = '"%s"' % command
+        if "{cmd}" not in shell:
+            shell += '"{cmd}"'
     else:
-        shell = ""
+        shell = "{}"
     # Resulting string should now have correct formatting
-    return sudo_prefix + shell + command
+    return sudo_prefix + shell.format(cmd=command)
 
 
 def _prefix_commands(command, which):

--- a/sites/docs/usage/env.rst
+++ b/sites/docs/usage/env.rst
@@ -688,6 +688,9 @@ takes a command string as its value.
 .. seealso:: :option:`--shell <-s>`,
              :ref:`FAQ on bash as default shell <faq-bash>`, :doc:`execution`
 
+.. note:: env.shell can also be a format-string using '{cmd}' for command
+          replacement
+
 .. _skip-bad-hosts:
 
 ``skip_bad_hosts``


### PR DESCRIPTION
this allows env['shell'] to be a format string, which is very useful when using containers to run commands such as
'echo "command && exit" | nsenter ...'
