### PR TITLE
Close fds before the child process is executed

### DIFF
--- a/fabric/operations.py
+++ b/fabric/operations.py
@@ -1165,12 +1165,9 @@ def local(command, capture=False, shell=None):
         err_stream = None if output.stderr else dev_null
     try:
         cmd_arg = wrapped_command if win32 else [wrapped_command]
-        if shell is not None:
-            p = subprocess.Popen(cmd_arg, shell=True, stdout=out_stream,
-                                 stderr=err_stream, executable=shell)
-        else:
-            p = subprocess.Popen(cmd_arg, shell=True, stdout=out_stream,
-                                 stderr=err_stream)
+        p = subprocess.Popen(cmd_arg, shell=True, stdout=out_stream,
+                             stderr=err_stream, executable=shell,
+                             close_fds=(not win32))
         (stdout, stderr) = p.communicate()
     finally:
         if dev_null is not None:


### PR DESCRIPTION
All file descriptors except 0, 1 and 2 are closed before the child process is executed. (Unix only)

I call `fabric.api.local` function to start service in my python application, which open a port to accept HTTP connections, then stop the application, the opened port will be attached to the service! I cannot run my python application again, since the port is already used.

The default value of the executable parameter of the `subprocess.Popen` function is `None`, so we don't need the condition `if shell is not None:`
