### PR TITLE
add retry if auth error in parallel mode

### DIFF
--- a/fabric/network.py
+++ b/fabric/network.py
@@ -532,6 +532,7 @@ def connect(user, host, port, cache, seek_gateway=True):
             if env.parallel:
                 if _tried_enough(tries):
                     password = prompt_for_password(text)
+                continue
             else:
                 password = prompt_for_password(text)
             # Update env.password, env.passwords if empty


### PR DESCRIPTION
We have issue with multiple (more than 10 nodes) ssh connections in parallel mode. This patch resolve the issue.
