### PR TITLE
Fix Issue 1191

### DIFF
--- a/fabric/utils.py
+++ b/fabric/utils.py
@@ -9,7 +9,7 @@ from traceback import format_exc
 
 
 def _encode(msg, stream):
-    if isinstance(msg, unicode) and hasattr(stream, 'encoding'):
+    if isinstance(msg, unicode) and hasattr(stream, 'encoding') and stream.encoding:
         return msg.encode(stream.encoding)
     else:
         return str(msg)


### PR DESCRIPTION
https://github.com/fabric/fabric/issues/1191

A very simple example showing a stream with null encoding is:
$ python -c 'import sys; print sys.stdout.encoding' | tee
