### PR TITLE
Include error message in task abort exception

### DIFF
--- a/fabric/utils.py
+++ b/fabric/utils.py
@@ -39,7 +39,7 @@ def abort(msg):
     if env.abort_exception:
         raise env.abort_exception(msg)
     else:
-        sys.exit(1)
+        sys.exit(msg)
 
 
 def warn(msg):


### PR DESCRIPTION
According to https://docs.python.org/2/library/sys.html the sys.exit([arg]) call will still result in error code of 1 for any non-zero object given. But at least by providing the error message it can be caught and inspected by the running program first.
