### PR TITLE
Fix issue #1032 that hosts and roles decorators violate fab -d task

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ if sys.version_info[:2] < (2, 6):
     install_requires=['paramiko>=1.10,<1.13']
 else:
     install_requires=['paramiko>=1.10']
+install_requires.append('decorator>=3.4.0')
 
 
 setup(


### PR DESCRIPTION
I fixed issue #1032 .

And in this patch, I also added 3 tests.
1-1. hosts/roles decorator should preserve the argument **func's** sigunature.
1-2. hosts/roles decorator should preserve the argument **func's** sigunature even if **func** is subclass of tasks.Task.
2. hosts/roles decorator should not change the argument **func** itself.

To pass test-2, I use python decorator module ( https://pypi.python.org/pypi/decorator ).
