### PR TITLE
Fix underlying exception reporting for CommandTimeout exceptions

### DIFF
--- a/fabric/exceptions.py
+++ b/fabric/exceptions.py
@@ -24,4 +24,9 @@ class NetworkError(Exception):
 
 
 class CommandTimeout(Exception):
-    pass
+    def __init__(self, timeout):
+        self.timeout = timeout
+
+        message = 'Command failed to finish in %s seconds' % (timeout)
+        self.message = message
+        super(CommandTimeout, self).__init__(message)

--- a/fabric/io.py
+++ b/fabric/io.py
@@ -88,7 +88,7 @@ class OutputLooper(object):
             except socket.timeout:
                 elapsed = time.time() - start
                 if self.timeout is not None and elapsed > self.timeout:
-                    raise CommandTimeout
+                    raise CommandTimeout(timeout=self.timeout)
                 continue
             # Empty byte == EOS
             if bytelist == '':


### PR DESCRIPTION
Currently if you run tasks in parallel mode and one of the hosts throws `CommandTimeout`, `fabric.utils.error` will return underlying exception as an empty string.

For example:

```
Fatal error: One or more hosts failed while executing task 'local'

Underlying exception:


Aborting.
```

The reason for that is that `CommandTimeout` class doesn't have `message` attribute so calling `str()` on it will return an empty string.

> In [1]: from fabric.exceptions import CommandTimeout
> 
> In [2]: str(CommandTimeout())
> Out[2]: ''

In this pull request I've added `message` attribute to the class so the underlying exception is now reported correctly.

> In [1]: from fabric.exceptions import CommandTimeout
> 
> In [2]: str(CommandTimeout(1))
> Out[2]: 'Command failed to finish in 1 seconds'
