### PR TITLE
Patch for #1226

### DIFF
--- a/fabric/sftp.py
+++ b/fabric/sftp.py
@@ -166,6 +166,7 @@ class SFTP(object):
             # (The target path has already been cwd-ified elsewhere.)
             with settings(hide('everything'), cwd=""):
                 sudo('cp -p "%s" "%s"' % (remote_path, target_path))
+                sudo('chown %s:%s "%s"' % (env.user, env.user, target_path))
                 # Only root and the user has the right to read the file
                 sudo('chmod %o "%s"' % (0404, target_path))
                 remote_path = target_path

--- a/sites/www/changelog.rst
+++ b/sites/www/changelog.rst
@@ -1,7 +1,8 @@
 =========
 Changelog
 =========
-
+* :bug:`1226` Update `~fabric.sftp` to ensure ``env.user`` has access to 
+  files before calling ``chmod 0404`` on the file. Patch by Curtis Mattoon.
 * :release:`1.10.0 <2014-09-04>`
 * :bug:`1188 major` Update `~fabric.operations.local` to close non-pipe file
   descriptors in the child process so subsequent calls to


### PR DESCRIPTION
Use `chown` to ensure the user maintains access to the file, even if it is owned by a different user. Setting permissions 0404/0400 blocks the user from accessing the file.
