### PR TITLE
Fix for #1226. Ensures user has ownership of tempfiles

### DIFF
--- a/fabric/sftp.py
+++ b/fabric/sftp.py
@@ -163,8 +163,10 @@ class SFTP(object):
             # (The target path has already been cwd-ified elsewhere.)
             with settings(hide('everything'), cwd=""):
                 sudo('cp -p "%s" "%s"' % (remote_path, target_path))
+                # The user should always own the copied file.
+                sudo('chown %s:%s "%s"' % (env.user, env.user, target_path))
                 # Only root and the user has the right to read the file
-                sudo('chmod %o "%s"' % (0404, target_path))
+                sudo('chmod %o "%s"' % (0400, target_path))
                 remote_path = target_path
 
         try:

--- a/sites/www/changelog.rst
+++ b/sites/www/changelog.rst
@@ -2,6 +2,9 @@
 Changelog
 =========
 
+* :bug:`1226` Update `~fabric.sftp.get` to ensure that `env.user` has access
+  to tempfiles before changing permissions. Also corrected permissions from
+  404 to 0400 to match comment. Patch by Curtis Mattoon.
 * :release:`1.10.0 <2014-09-04>`
 * :bug:`1188 major` Update `~fabric.operations.local` to close non-pipe file
   descriptors in the child process so subsequent calls to


### PR DESCRIPTION
Two modifications:
- Use `chown` to `env.user`:`env.user` before calling `chmod`
- `chmod` now sets permissions 0400 instead of 404, to match the intent of the comment
  > # Only root and the user has the right to read the file

(Change to previous request, which was inadvertently based off of `master`)
