### PR TITLE
Fixes #1135. Command prefix is applied before shell_env.

### DIFF
--- a/fabric/operations.py
+++ b/fabric/operations.py
@@ -904,7 +904,7 @@ def _run_command(command, shell=True, pty=True, combine_stderr=True,
 
         # Handle context manager modifications, and shell wrapping
         wrapped_command = _shell_wrap(
-            _prefix_commands(_prefix_env_vars(command), 'remote'),
+            _prefix_env_vars(_prefix_commands(command, 'remote')),
             shell_escape,
             shell,
             _sudo_prefix(user, group) if sudo else None

--- a/sites/www/changelog.rst
+++ b/sites/www/changelog.rst
@@ -1,7 +1,9 @@
 =========
 Changelog
 =========
-
+* :bug:`1135` Modified order of operations in ``_run_command()`` to apply
+  environment vars before prefixing commands. Report by ``@warsamebashir``,
+  patch by ``@cmattoon``.
 * :support:`1239` Update README to work better under raw docutils so the
   example code block is highlighted as Python on PyPI (and not just on our
   Sphinx-driven website). Thanks to Marc Abramowitz.


### PR DESCRIPTION
Reverses the order in which `shell_env` and `prefix` are applied to a command. 