### PR TITLE
Fix check `destination` is a directory

### DIFF
--- a/fabric/contrib/files.py
+++ b/fabric/contrib/files.py
@@ -110,7 +110,7 @@ def upload_template(filename, destination, context=None, use_jinja=False,
         func = partial(func, pty=pty)
     # Normalize destination to be an actual filename, due to using StringIO
     with settings(hide('everything'), warn_only=True):
-        if func('test -d %s' % _expand_path(destination)).succeeded:
+        if func('test -d %s' % destination).succeeded:
             sep = "" if destination.endswith('/') else "/"
             destination += sep + os.path.basename(filename)
 

--- a/tests/test_contrib.py
+++ b/tests/test_contrib.py
@@ -15,7 +15,7 @@ class TestContrib(FabricTest):
     # Make sure it knows / is a directory.
     # This is in lieu of starting down the "actual honest to god fake operating
     # system" road...:(
-    @server(responses={'test -d "$(echo /)"': ""})
+    @server(responses={'test -d /': ""})
     def test_upload_template_uses_correct_remote_filename(self):
         """
         upload_template() shouldn't munge final remote filename


### PR DESCRIPTION
it's a fabfile.py:

``` python
from fabric.contrib.files import upload_template

context = {
    'name': 'oscarmlage',
}

def update_temp():
    upload_template(filename='xmas.conf',
                    destination='/home/vagrant/test/tmp/',
                    context=context,
                    template_dir='.',
                    use_jinja=True)
```

when i execute it at freebsd:

``` python
➜  test  fab -H localhost update_temp --colorize-errors 
[localhost] Executing task 'update_temp'
[localhost] put: <file obj> -> /home/vagrant/test/tmp/

Fatal error: put() encountered an exception while uploading '<StringIO.StringIO instance at 0x804415f80>'

Underlying exception:
    Failure

Aborting.
Disconnecting from localhost... done.
put() encountered an exception while uploading '<StringIO.StringIO instance at 0x804415f80>'

Underlying exception:
    Failure

➜  test  ipython
In [1]: import os

In [2]: os.path.isdir('/home/vagrant/test/tmp/')
Out[2]: True
```
