### PR TITLE
fix Unmatched or `No such file or directory` errors

### DIFF
--- a/fabric/sftp.py
+++ b/fabric/sftp.py
@@ -286,7 +286,7 @@ class SFTP(object):
             # Temporarily nuke 'cwd' so sudo() doesn't "cd" its mv command.
             # (The target path has already been cwd-ified elsewhere.)
             with settings(hide('everything'), cwd=""):
-                sudo("mv \"%s\" \"%s\"" % (remote_path, target_path))
+                sudo("mv '%s' '%s'" % (remote_path, target_path))
             # Revert to original remote_path for return value's sake
             remote_path = target_path
         return remote_path


### PR DESCRIPTION
In #1155. here is a `No such file or directory` error. and in my freebsd has other error like this:

``` python
Fatal error: sudo() received nonzero return code 1 while executing!

Requested: mv "939cd8c72cb4a131c94118e1f5a11c1c0178696d" "/home/vagrant/test/tmp/1.conf"
Executed: sudo -S -p 'sudo password:'  /bin/bash -l -c "mv \"939cd8c72cb4a131c94118e1f5a11c1c0178696d\" \"/home/vagrant/test/tmp/1.conf\""

======================================================= Standard output =======================================================

Unmatched ".

===============================================================================================================================

Aborting.
```

the fabfile is:

``` python
# coding=utf-8

from fabric.contrib.files import upload_template
import logging
logging.basicConfig(level=logging.DEBUG)

context = {
    'name': 'oscarmlage',
}

def update_temp():
    upload_template(filename='xmas.conf',
                    destination='/home/vagrant/test/tmp/1.conf',
                    context=context,
                    template_dir='.',
                    use_jinja=True,
                    use_sudo=True)
```
