### PR TITLE
Remove obsolete use of operator.isMappingType

### DIFF
--- a/fabric/main.py
+++ b/fabric/main.py
@@ -9,7 +9,7 @@ The other callables defined in this module are internal only. Anything useful
 to individuals leveraging Fabric as a library, should be kept elsewhere.
 """
 import getpass
-from operator import isMappingType
+from collections import Mapping
 from optparse import OptionParser
 import os
 import sys
@@ -361,7 +361,7 @@ def _sift_tasks(mapping):
     for name, value in mapping.iteritems():
         if _is_task(name, value):
             tasks.append(name)
-        elif isMappingType(value):
+        elif isinstance(value, Mapping):
             collections.append(name)
     tasks = sorted(tasks)
     collections = sorted(collections)


### PR DESCRIPTION
Though still won't work in Python 3, this might be a little step forward as it's obsolete since 2.7.