### PR TITLE
Initial support for using Kerberos.

### DIFF
--- a/fabric/network.py
+++ b/fabric/network.py
@@ -140,7 +140,7 @@ class HostConnectionCache(dict):
         Force a new connection to ``key`` host string.
         """
         from fabric.state import env
-        
+
         user, host, port = normalize(key)
         key = normalize_to_string(key)
         seek_gateway = True
@@ -449,7 +449,11 @@ def connect(user, host, port, cache, seek_gateway=True):
                 timeout=env.timeout,
                 allow_agent=not env.no_agent,
                 look_for_keys=not env.no_keys,
-                sock=sock
+                sock=sock,
+                gss_auth=env.gss_auth,
+                gss_deleg_creds=env.gss_deleg,
+                gss_kex=env.gss_kex,
+                gss_host=host,
             )
             connected = True
 

--- a/fabric/state.py
+++ b/fabric/state.py
@@ -141,6 +141,24 @@ env_options = [
         help="gateway host to connect through"
     ),
 
+    make_option('--gss-auth',
+        action='store_true',
+        default=False,
+        help="Use GSS-API authentication"
+    ),
+
+    make_option('--gss-deleg',
+        action='store_true',
+        default=False,
+        help="Delegate GSS-API client credentials or not"
+    ),
+
+    make_option('--gss-kex',
+        action='store_true',
+        default=False,
+        help="Perform GSS-API Key Exchange and user authentication"
+    ),
+
     make_option('--hide',
         metavar='LEVELS',
         help="comma-separated list of output levels to hide"


### PR DESCRIPTION
Support 3 additional parameters when connecting to hosts: gss-auth,
gss-deleg, gss-kex. These correspond to the equivalent in paramiko. It
does all the hard work.