### PR TITLE
Update installing.rst

### DIFF
--- a/sites/www/installing.rst
+++ b/sites/www/installing.rst
@@ -56,7 +56,7 @@ Please read on for important details on these -- there are a few gotchas.
 Python
 ------
 
-Fabric requires `Python <http://python.org>`_ version 2.5 or 2.6. Some caveats
+Fabric requires `Python <http://python.org>`_ version 2.5 - 2.7. Some caveats
 and notes about other Python versions:
 
 * We are not planning on supporting **Python 2.4** given its age and the number


### PR DESCRIPTION
I noticed that this doc page said Fabric only supports Python 2.5 and 2.6 whereas Github states it also supports 2.7 (https://github.com/fabric/fabric)