### PR TITLE
Swapped non-ASCII character for (c) to fix broken build

### DIFF
--- a/tests/Python26SocketServer.py
+++ b/tests/Python26SocketServer.py
@@ -118,7 +118,7 @@ BaseServer:
   entry is processed by a RequestHandlerClass.
 
 """
-# This file copyright © 2001-2015 Python Software Foundation; All Rights Reserved
+# This file copyright (c) 2001-2015 Python Software Foundation; All Rights Reserved
 
 # Author of the BaseServer patch: Luke Kenneth Casson Leighton
 


### PR DESCRIPTION
The build is failing because of a non-ASCII character. The file's encoding could be updated, or the character could be swapped, which is included in this commit.