### PR TITLE
Fixed "NameError: free variable 'chan' referenced before assignment in enclosing scope".

### DIFF
--- a/fabric/context_managers.py
+++ b/fabric/context_managers.py
@@ -52,9 +52,9 @@ def _set_output(groups, which):
     """
     Refactored subroutine used by ``hide`` and ``show``.
     """
+    previous = {}
     try:
         # Preserve original values, pull in new given value to use
-        previous = {}
         for group in output.expand_aliases(groups):
             previous[group] = output[group]
             output[group] = which
@@ -542,7 +542,7 @@ def remote_tunnel(remote_port, local_port=None, local_host="localhost",
             sock.connect((local_host, local_port))
         except Exception, e:
             print "[%s] rtunnel: cannot connect to %s:%d (from local)" % (env.host_string, local_host, local_port)
-            chan.close()
+            channel.close()
             return
 
         print "[%s] rtunnel: opened reverse tunnel: %r -> %r -> %r"\

--- a/sites/www/changelog.rst
+++ b/sites/www/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`1289` Fix "NameError: free variable referenced before assignment in enclosing scope". Thanks to ``@SamuelMarks`` for catch & patch.
 * :bug:`1273` Fix issue with ssh/config not having a cross-platform default path. Thanks to ``@SamuelMarks`` for catch & patch.
 * :feature:`1200` Introduced ``exceptions`` output level, so users don't have to
   deal with the debug output just to see tracebacks.


### PR DESCRIPTION
Additionally `previous` was referenced before assignment, so moved it up a scope level.