### PR TITLE
Fixed "NameError: free variable 'chan' referenced before assignment in enclosing scope"

### DIFF
--- a/fabric/context_managers.py
+++ b/fabric/context_managers.py
@@ -34,7 +34,6 @@ Context managers for use with the ``with`` statement.
 """
 
 from contextlib import contextmanager, nested
-import sys
 import socket
 import select
 
@@ -51,9 +50,9 @@ def _set_output(groups, which):
     """
     Refactored subroutine used by ``hide`` and ``show``.
     """
+    previous = {}
     try:
         # Preserve original values, pull in new given value to use
-        previous = {}
         for group in output.expand_aliases(groups):
             previous[group] = output[group]
             output[group] = which
@@ -541,7 +540,7 @@ def remote_tunnel(remote_port, local_port=None, local_host="localhost",
             sock.connect((local_host, local_port))
         except Exception, e:
             print "[%s] rtunnel: cannot connect to %s:%d (from local)" % (env.host_string, local_host, local_port)
-            chan.close()
+            channel.close()
             return
 
         print "[%s] rtunnel: opened reverse tunnel: %r -> %r -> %r"\
@@ -563,7 +562,6 @@ def remote_tunnel(remote_port, local_port=None, local_host="localhost",
             th.thread.join()
             th.raise_if_needed()
         transport.cancel_port_forward(remote_bind_address, remote_port)
-
 
 
 quiet = lambda: settings(hide('everything'), warn_only=True)

--- a/sites/www/changelog.rst
+++ b/sites/www/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`1289` Fix "NameError: free variable referenced before assignment in enclosing scope". Thanks to ``@SamuelMarks`` for catch & patch.
 * :release:`1.9.1 <2014-08-06>`
 * :release:`1.8.5 <2014-08-06>`
 * :release:`1.7.5 <2014-08-06>`


### PR DESCRIPTION
Additionally `previous` was referenced before assignment, so moved it up a scope level; and the `sys` import was unused.