### PR TITLE
Docs on "Running Tests"

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -13,4 +13,4 @@ Sphinx>=1.2
 releases==0.6.1
 invoke==0.7.0
 invocations==0.5.0
-alabaster==0.6.1
+alabaster>=0.6.1

--- a/sites/docs/index.rst
+++ b/sites/docs/index.rst
@@ -76,3 +76,14 @@ backwards-compatible) as more use-cases are solved and added.
     :glob:
 
     api/contrib/*
+
+
+Contributing & Running Tests
+----------------------------
+
+For advanced users & developers looking to help fix bugs or add new features.
+
+.. toctree::
+    :hidden:
+
+    running_tests

--- a/sites/docs/running_tests.rst
+++ b/sites/docs/running_tests.rst
@@ -1,0 +1,48 @@
+======================
+Running Fabric's Tests
+======================
+
+Fabric is maintained with 100% passing tests. Where possible, patches should
+include tests covering the changes, making things far easier to verify & merge.
+
+When developing on Fabric, it works best to establish a `virtualenv`_ to install
+the dependencies in isolation for running tests.
+
+.. _`virtualenv`: https://virtualenv.pypa.io/en/latest/
+
+.. _first-time-setup:
+
+First-time Setup
+================
+
+* Fork the `repository`_ on GitHub
+* Clone your new fork (e.g.
+  ``git clone git@github.com:<your_username>/fabric.git``)
+* ``cd fabric``
+* ``virtualenv env``
+* ``. env/bin/activate``
+* ``pip install -r requirements.txt``
+* ``python setup.py develop``
+
+.. _`repository`: https://github.com/fabric/fabric
+
+.. _running-tests:
+
+Running Tests
+=============
+
+Once your virtualenv is activated (``. env/bin/activate``) & you have the latest
+requirements, running tests is just::
+
+    nosetests tests/
+
+You should **always** run tests on ``master`` (or the release branch you're
+working with) to ensure they're passing before working on your own
+changes/tests.
+
+Alternatively, if you've run ``python setup.py develop`` on your Fabric clone,
+you can also run::
+
+    fab test
+
+This adds additional flags which enable running doctests & adds nice coloration.


### PR DESCRIPTION
Here's a first blush at docs around running tests. The `alabaster` bump was necessary because Sphinx locally refused to build (`pkg_resources.DistributionNotFound: alabaster>=0.7,<0.8`), which is a separate commit so it can be cherry-picked if necessary.

Fixes #1309