### PR TITLE
Redirect cd output to /dev/null in case of CDPATH

### DIFF
--- a/fabric/operations.py
+++ b/fabric/operations.py
@@ -658,7 +658,7 @@ def _prefix_commands(command, which):
     # prefixed command to be "in" the current working directory.
     cwd = env.cwd if which == 'remote' else env.lcwd
     if cwd:
-        prefixes.insert(0, 'cd %s' % cwd)
+        prefixes.insert(0, 'cd %s >/dev/null' % cwd)
     glue = " && "
     prefix = (glue.join(prefixes) + glue) if prefixes else ""
     return prefix + command

--- a/fabric/operations.py
+++ b/fabric/operations.py
@@ -657,8 +657,9 @@ def _prefix_commands(command, which):
     # Also place it at the front of the list, in case user is expecting another
     # prefixed command to be "in" the current working directory.
     cwd = env.cwd if which == 'remote' else env.lcwd
+    redirect = " >/dev/null" if not win32 else ''
     if cwd:
-        prefixes.insert(0, 'cd %s >/dev/null' % cwd)
+        prefixes.insert(0, 'cd %s%s' % (cwd, redirect))
     glue = " && "
     prefix = (glue.join(prefixes) + glue) if prefixes else ""
     return prefix + command

--- a/tests/test_context_managers.py
+++ b/tests/test_context_managers.py
@@ -124,6 +124,22 @@ def test_cd_prefix():
         command_out = _prefix_commands('foo', "remote")
         eq_(command_out, 'cd %s >/dev/null && foo' % some_path)
 
+
+# def test_cd_prefix_on_win32():
+#     """
+#     cd prefix should NOT direct output to /dev/null on win32
+#     """
+#     some_path = "~/somepath"
+
+#     import fabric
+#     try:
+#         fabric.state.win32 = True
+#         with cd(some_path):
+#             command_out = _prefix_commands('foo', "remote")
+#             eq_(command_out, 'cd %s && foo' % some_path)
+#     finally:
+#         fabric.state.win32 = False
+
 #
 # hide/show
 #

--- a/tests/test_context_managers.py
+++ b/tests/test_context_managers.py
@@ -9,7 +9,7 @@ from nose.tools import eq_, ok_
 from fabric.state import env, output
 from fabric.context_managers import (cd, settings, lcd, hide, shell_env, quiet,
     warn_only, prefix, path)
-from fabric.operations import run, local
+from fabric.operations import run, local, _prefix_commands
 from utils import mock_streams, FabricTest
 from server import server
 
@@ -110,6 +110,19 @@ def test_nested_prefix():
         with cm2:
             eq_(env.command_prefixes, ['1', '2'])
 
+#
+# cd prefix with dev/null
+#
+
+def test_cd_prefix():
+    """
+    cd prefix should direct output to /dev/null in case of CDPATH
+    """
+    some_path = "~/somepath"
+
+    with cd(some_path):
+        command_out = _prefix_commands('foo', "remote")
+        eq_(command_out, 'cd %s >/dev/null && foo' % some_path)
 
 #
 # hide/show


### PR DESCRIPTION
This redirects the output of the `cd` command to `/dev/null` so that in cases where `CDPATH` is set, the output from `cd` won't be captured. Will not add the redirect on Windows. Fixes #980.