### PR TITLE
Fix example of Job Queue

### DIFF
--- a/fabric/job_queue.py
+++ b/fabric/job_queue.py
@@ -8,6 +8,7 @@ items, though within Fabric itself only ``Process`` objects are used/supported.
 from __future__ import with_statement
 import time
 import Queue
+from multiprocessing import Process
 
 from fabric.state import env
 from fabric.network import ssh
@@ -175,7 +176,8 @@ class JobQueue(object):
 
         # Attach exit codes now that we're all done & have joined all jobs
         for job in self._completed:
-            results[job.name]['exit_code'] = job.exitcode
+            if isinstance(job, Process):
+                results[job.name]['exit_code'] = job.exitcode
 
         return results
 

--- a/fabric/job_queue.py
+++ b/fabric/job_queue.py
@@ -213,7 +213,8 @@ def try_using(parallel_type):
         from threading import Thread as Bucket
 
     # Make a job_queue with a bubble of len 5, and have it print verbosely
-    jobs = JobQueue(5)
+    queue = Queue.Queue()
+    jobs = JobQueue(5, queue)
     jobs._debug = True
 
     # Add 20 procs onto the stack


### PR DESCRIPTION
Fixes an example for the job queue constructor (which now requires a second positional argument, intended to be a Queue() object)

Also addresses <https://github.com/fabric/fabric/issues/1305#issuecomment-92333680> . We'll now only set exit status if it's a process and do nothing if it's a thread.