### PR TITLE
Tox integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.egg
 .DS_Store
 .*.swp
+.eggs
 Fabric.egg-info
 .coverage
 docs/_build
@@ -14,6 +15,5 @@ build/
 tags
 TAGS
 .tox
-tox.ini
 .idea/
 sites/*/_build

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -13,4 +13,4 @@ Sphinx>=1.2
 releases==0.6.1
 invoke==0.7.0
 invocations==0.5.0
-alabaster==0.6.1
+alabaster>=0.6.1

--- a/sites/docs/index.rst
+++ b/sites/docs/index.rst
@@ -76,3 +76,14 @@ backwards-compatible) as more use-cases are solved and added.
     :glob:
 
     api/contrib/*
+
+
+Contributing & Running Tests
+----------------------------
+
+For advanced users & developers looking to help fix bugs or add new features.
+
+.. toctree::
+    :hidden:
+
+    running_tests

--- a/sites/docs/running_tests.rst
+++ b/sites/docs/running_tests.rst
@@ -46,3 +46,26 @@ you can also run::
     fab test
 
 This adds additional flags which enable running doctests & adds nice coloration.
+
+
+Testing against multiple versions of Python
+===========================================
+
+In order to make testing against multiple versions of Python easier, the
+testsuite can also be executed using tox_ (outside the virtualenv you created
+above).  Tox will handle all the virtual environments for you out of the box.
+
+To execute the whole test suite against Python 2.5 - 2.7 you can simply run::
+
+    tox
+
+If you just want to run the tests specified in, for instance,
+``tests/test_parallel.py`` against Python 2.7 run::
+
+    tox -e py27 -- tests/test_parallel.py
+
+Note that tox won't install the various Python versions for you. So if you want
+to test against Python 2.5 you have to have that installed prior to running
+tests against it.
+
+.. _tox: https://tox.readthedocs.org/

--- a/sites/docs/running_tests.rst
+++ b/sites/docs/running_tests.rst
@@ -1,0 +1,48 @@
+======================
+Running Fabric's Tests
+======================
+
+Fabric is maintained with 100% passing tests. Where possible, patches should
+include tests covering the changes, making things far easier to verify & merge.
+
+When developing on Fabric, it works best to establish a `virtualenv`_ to install
+the dependencies in isolation for running tests.
+
+.. _`virtualenv`: https://virtualenv.pypa.io/en/latest/
+
+.. _first-time-setup:
+
+First-time Setup
+================
+
+* Fork the `repository`_ on GitHub
+* Clone your new fork (e.g.
+  ``git clone git@github.com:<your_username>/fabric.git``)
+* ``cd fabric``
+* ``virtualenv env``
+* ``. env/bin/activate``
+* ``pip install -r requirements.txt``
+* ``python setup.py develop``
+
+.. _`repository`: https://github.com/fabric/fabric
+
+.. _running-tests:
+
+Running Tests
+=============
+
+Once your virtualenv is activated (``. env/bin/activate``) & you have the latest
+requirements, running tests is just::
+
+    nosetests tests/
+
+You should **always** run tests on ``master`` (or the release branch you're
+working with) to ensure they're passing before working on your own
+changes/tests.
+
+Alternatively, if you've run ``python setup.py develop`` on your Fabric clone,
+you can also run::
+
+    fab test
+
+This adds additional flags which enable running doctests & adds nice coloration.

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+envlist = py{25,26,27}
+
+[testenv]
+basepython =
+    py25: python2.5
+    py26: python2.6
+    py27: python2.7
+deps =
+    -rrequirements.txt
+commands =
+    nosetests -sv --with-doctest --nologcapture {posargs:tests/}


### PR DESCRIPTION
This PR is built on top of #1310 and adds a simple tox.ini file for running the tests against Python 2.5 - 2.7 if the user has all of them installed.

It also includes an update to the documentation to demonstrate how to use tox for common use-cases.