### PR TITLE
Fix for #1294

### DIFF
--- a/sites/www/changelog.rst
+++ b/sites/www/changelog.rst
@@ -1,7 +1,8 @@
 =========
 Changelog
 =========
-
+* :bug:`1294` Fix regex escaping to allow pipes in text. Reported by
+  ``@ecksun``, patch by ``@cmattoon``.
 * :bug:`1305` (also :issue:`1313`) Fix a couple minor issues with the operation
   of & demo code for the ``JobQueue`` class. Thanks to ``@dioh`` and Horst
   Gutmann for the report & Cameron Lane for the patch.

--- a/tests/test_contrib.py
+++ b/tests/test_contrib.py
@@ -4,7 +4,7 @@ from fabric.operations import local
 import os
 
 from fabric.api import hide, get, show
-from fabric.contrib.files import upload_template, contains
+from fabric.contrib.files import upload_template, contains, _escape_for_regex
 from fabric.context_managers import lcd
 
 from utils import FabricTest, eq_contents
@@ -129,3 +129,16 @@ class TestContrib(FabricTest):
                     template_name, remote, {'varname': var},
                     mirror_local_mode=mirror
                 )
+
+    def test_escape_for_regex_allows_pipes(self):
+        valid = {
+            r"cat file1 > file2": r'cat\ file1 > file2',
+            r"cat file2 >> file3": r'cat\ file2 >> file3',
+            r"ls > dirlist 2>&1": r'ls > dirlist\ 2\>\&1',
+            r"<html><head></head><body>":r'\<html\>\<head\>\<\/head\>\<body\>',
+            r"Mailto: <cmattoon@cmattoon.com>": r'Mailto\:\ \<cmattoon\@cmattoon\.com\>',
+            r"cat file3 | more": r'cat\ file3 | more'
+            }
+
+        for (text, expected) in valid.iteritems():
+            assert expected == _escape_for_regex(text)


### PR DESCRIPTION
In favor of keeping it simple, I went with the approach of replacing pipes with a (hopefully) unique string. This allows re.escape to ignore the string completely. Then, just sub it back in at the end.

Since <, >, & and | can be used in both regex and as redirects/pipes, the function distinguishes the two by whether or not there's a leading and trailing space. (|regex| vs cat file | more).Things like 2>&1 would still be escaped, but that could be handled easily by hard-coding common redirects, or using regex. I'm not sure I'm thrilled with either.

Apologies for the messy test; I'll try and get something more appropriate (and that reflects the underlying issue with contains and append more closely) later.

(Removed whitespace & rebased on `master`)
