### PR TITLE
Expose the Changelog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,3 @@
+The CHANGELOG is maintained in the `sites/www/changelog.rst <sites/www/changelog.rst>`_ file.
+
+It is viewable online as HTML at `fabfile.org/changelog.html <http://http://www.fabfile.org/changelog.html>`_.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,3 @@
 The CHANGELOG is maintained in the `sites/www/changelog.rst <sites/www/changelog.rst>`_ file.
 
-It is viewable online as HTML at `fabfile.org/changelog.html <http://http://www.fabfile.org/changelog.html>`_.
+It is viewable online as HTML at `fabfile.org/changelog.html <http://www.fabfile.org/changelog.html>`_.


### PR DESCRIPTION
I couldn't find the changelog until I did quite a bit of searching, because it's hidden in a subdirectory.

I propose the following patch -- it simply adds a CHANGELOG.rst file on the top level (where one would expect it to me) that identifies the actual changelog, and gives a link to the HTML version on fabfile.org