### PR TITLE
Fixes #1348: handle % chars in get() in a better way

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,6 +25,9 @@ would have also been included in the 1.2 line.
 Changelog
 =========
 
+* :bug:`1348` Fix get() to not break when string format chars appear in files
+  on the remote server. Thanks `@natecode` for the bug report and `@bspink`
+  for the fix.
 * :release:`1.5.5 <2013-12-24>`
 * :bug:`956` Fix pty size detection when running inside Emacs. Thanks to
   `@akitada` for catch & patch.

--- a/fabric/sftp.py
+++ b/fabric/sftp.py
@@ -125,9 +125,10 @@ class SFTP(object):
             'path': rremote
         }
         if local_is_path:
-            # Naive fix to issue #711
-            escaped_path = re.sub(r'(%[^()]*\w)', r'%\1', local_path)
-            local_path = os.path.abspath(escaped_path % path_vars )
+            # Fix for issue #711 and #1348 - escape %'s as well as possible.
+            format_re = r'(%%(?!\((?:%s)\)\w))' % '|'.join(path_vars.keys())
+            escaped_path = re.sub(format_re, r'%\1', local_path)
+            local_path = os.path.abspath(escaped_path % path_vars)
 
             # Ensure we give ssh.SFTPCLient a file by prepending and/or
             # creating local directories as appropriate.

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -386,6 +386,15 @@ class TestFileTransfers(FabricTest):
             # Another if-it-doesn't-error-out-it-passed test; meh.
             eq_(get('.bashrc', self.path()), [self.path('.bashrc')])
 
+    @server(files={'/top/%a/%(/%()/%(x)/%(no)s/%(host)s/%d': 'yo'})
+    def test_get_with_format_chars_on_server(self):
+        """
+        get('*') with format symbols (%) on remote paths should not break
+        """
+        remote = '*'
+        with hide('everything'):
+            get(remote, self.path())
+
     @server()
     def test_get_single_file(self):
         """


### PR DESCRIPTION
Improved the regex for escaping the % characters.

I put this against 1.5 as that's the earliest branch I could find this in (the contributions guide said to do this), and it still persists in master. The changelog file has moved location in master, so if you want me to change anything let me know. :) 