### PR TITLE
fix nested executions using non-standard ports

### DIFF
--- a/fabric/io.py
+++ b/fabric/io.py
@@ -2,7 +2,6 @@ from __future__ import with_statement
 
 import sys
 import time
-import os
 import re
 import socket
 from select import select
@@ -233,7 +232,7 @@ def input_loop(chan, using_pty):
             have_char = (r and r[0] == sys.stdin)
         if have_char and chan.input_enabled:
             # Send all local stdin to remote end's stdin
-            byte = msvcrt.getch() if win32 else os.read(sys.stdin.fileno(), 1)
+            byte = msvcrt.getch() if win32 else sys.stdin.read(1)
             chan.sendall(byte)
             # Optionally echo locally, if needed.
             if not using_pty and env.echo_stdin:

--- a/fabric/io.py
+++ b/fabric/io.py
@@ -2,6 +2,7 @@ from __future__ import with_statement
 
 import sys
 import time
+import os
 import re
 import socket
 from select import select
@@ -232,7 +233,7 @@ def input_loop(chan, using_pty):
             have_char = (r and r[0] == sys.stdin)
         if have_char and chan.input_enabled:
             # Send all local stdin to remote end's stdin
-            byte = msvcrt.getch() if win32 else sys.stdin.read(1)
+            byte = msvcrt.getch() if win32 else os.read(sys.stdin.fileno(), 1)
             chan.sendall(byte)
             # Optionally echo locally, if needed.
             if not using_pty and env.echo_stdin:

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -613,7 +613,7 @@ class TestSSHConfig(FabricTest):
         """
         Global Port should NOT override nondefault env.port
         """
-        with settings(port="777"):
+        with settings(port="777", use_ssh_config=False):
             eq_(normalize("localhost")[2], "777")
 
     def test_specific_port_with_default_env(self):


### PR DESCRIPTION
Nested executions using non-default ports did not work as env.port was prioritized over hostname and ssh config derived port numbers.

See test_tasks.py:TestExecute.test_nested_execution_with_explicit_ports