### PR TITLE
Make it explicit that the sample needs to be saved as fabfile.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,9 @@ complete "fabfile" containing a single task:
     def host_type():
         run('uname -s')
 
-Once a task is defined, it may be run on one or more servers, like so::
+If you save the above as ``fabfile.py`` (the default module that
+``fab`` loads), you can run the tasks defined in it on one or more
+servers, like so::
 
     $ fab -H localhost,linuxbox host_type
     [localhost] run: uname -s


### PR DESCRIPTION
For folks who are new to Fabric (or coming back to after a long time), it can take sometime to figure out about the default file ``fabfile.py``, so just mentioning that explicitly. 