### PR TITLE
fix escape sequences in open_shell

### DIFF
--- a/fabric/io.py
+++ b/fabric/io.py
@@ -2,6 +2,7 @@ from __future__ import with_statement
 
 import sys
 import time
+import os
 import re
 import socket
 from select import select
@@ -232,7 +233,7 @@ def input_loop(chan, using_pty):
             have_char = (r and r[0] == sys.stdin)
         if have_char and chan.input_enabled:
             # Send all local stdin to remote end's stdin
-            byte = msvcrt.getch() if win32 else sys.stdin.read(1)
+            byte = msvcrt.getch() if win32 else os.read(sys.stdin.fileno(), 1)
             chan.sendall(byte)
             # Optionally echo locally, if needed.
             if not using_pty and env.echo_stdin:


### PR DESCRIPTION
In the context of open_shell with sys.stdin connected to a channel,
cursor movements appear "wonky", which can really mess up the user
experience.

An initial escape sequence is not captured correctly and only partially
sent across the channel resulting in no effect. A repeated key press
yields the correct sequence.

I suspect this is caused by a mismatch between select (mapped to a
syscall) and reading from the (buffered) sys.stdin. Dropping to the
lower-level os.read resolves this issue entirely.

NOTE: this may explain https://github.com/fabric/fabric/issues/196