### PR TITLE
Fix #1270 - Prevent installation on python3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
           'Operating System :: Unix',
           'Operating System :: POSIX',
           'Programming Language :: Python',
+          'Programming Language :: Python :: 2 :: Only',
           'Programming Language :: Python :: 2.5',
           'Programming Language :: Python :: 2.6',
           'Programming Language :: Python :: 2.7',


### PR DESCRIPTION
Given that python3 support isn't in this branch, it makes no sense to allow pip to install fabric.

This should make it bail out early.
