### PR TITLE
Add a missing `@contextmanager` decorator to `cd` context manager.

### DIFF
--- a/fabric/context_managers.py
+++ b/fabric/context_managers.py
@@ -243,6 +243,7 @@ def settings(*args, **kwargs):
     return nested(*managers)
 
 
+@contextmanager
 def cd(path):
     """
     Context manager that keeps directory state when calling remote operations.


### PR DESCRIPTION
This removes the following pylint warning on the usage of `with cd()`.
  * "Context manager 'generator' doesn't implement __enter__ and __exit__.
     (not-context-manager)"