### PR TITLE
Fabfile discovery: loading package with *.pyc only

### DIFF
--- a/fabric/main.py
+++ b/fabric/main.py
@@ -75,9 +75,10 @@ def _is_package(path):
     """
     Is the given path a Python package?
     """
+    _exists = lambda s: os.path.exists(os.path.join(path, s))
     return (
         os.path.isdir(path)
-        and os.path.exists(os.path.join(path, '__init__.py'))
+        and (_exists('__init__.py') or _exists('__init__.pyc'))
     )
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,6 +3,7 @@ from __future__ import with_statement
 import copy
 from functools import partial
 from operator import isMappingType
+import os.path
 import sys
 
 from fudge import Fake, patched_context
@@ -10,7 +11,7 @@ from nose.tools import ok_, eq_
 
 from fabric.decorators import hosts, roles, task
 from fabric.context_managers import settings
-from fabric.main import (parse_arguments, _escape_split,
+from fabric.main import (parse_arguments, _escape_split, find_fabfile,
         load_fabfile as _load_fabfile, list_commands, _task_names,
         COMMANDS_HEADER, NESTED_REMINDER)
 import fabric.state
@@ -357,6 +358,33 @@ def test_lazy_roles():
     def command():
         pass
     eq_hosts(command, ['a', 'b'], env={'roledefs': lazy_role})
+
+
+#
+# Fabfile finding
+#
+
+class TestFindFabfile(FabricTest):
+    """Test Fabric's fabfile discovery mechanism."""
+    def test_find_fabfile_can_discovery_package(self):
+        """Fabric should be capable of loading a normal package."""
+        path = self.mkfile("__init__.py", "")
+        name = os.path.dirname(path)
+        assert find_fabfile([name,]) is not None
+
+    def test_find_fabfile_can_discovery_package_with_pyc_only(self):
+        """
+        Fabric should be capable of loading a package with __init__.pyc only.
+        """
+        path = self.mkfile("__init__.pyc", "")
+        name = os.path.dirname(path)
+        assert find_fabfile([name,]) is not None
+
+    def test_find_fabfile_should_refuse_fake_package(self):
+        """Fabric should refuse to load a non-package directory."""
+        path = self.mkfile("foo.py", "")
+        name = os.path.dirname(path)
+        assert find_fabfile([name,]) is None
 
 
 #


### PR DESCRIPTION
    Fabfile discovery: loading package with *.pyc only

    As the doc (sites/docs/usage/fabfiles.rst, in "Fabfile discovery")
    says, Fabric is capable of loading Python modules (e.g. fabfile.py) or
    packages (e.g. a fabfile/ directory containing an __init__.py).
    Starting from version 0.9.2, Fabric has been capable of loading package
    fabfiles.

    However, Fabric's fabfile discovery algorithm only treats directories
    with an __init__.py file in them as legal Python packages.  It refuse
    to load any directories with an __init__.pyc file only (without
    __init__.py) in them, which are also legal Python packages.

    Fabric's current fabfile discovery algorithm works well for most cases.
    But in some cases, for example, suppose someone would like to release a
    tool, which consist of several Fabric tasks, in such a format that it
    only contains *.pyc files, i.e. he/she does not want to release the
    source code at all.  In such a case, users could run into trouble since
    Fabric refuse to load packages which only have an __init__.pyc in them.

    This commit gives Fabric the ability to load package fabfiles with
    __init__.pyc file only.

    This resolves #1427.