### PR TITLE
Fix Documentation for fabric.contrib.files.append()

### DIFF
--- a/fabric/contrib/files.py
+++ b/fabric/contrib/files.py
@@ -369,8 +369,10 @@ def append(filename, text, use_sudo=False, partial=False, escape=True,
     When a list is given, each string inside is handled independently (but in
     the order given.)
 
-    If ``text`` is already found in ``filename``, the append is not run. Otherwise, the given text is appended to the
-    end of the given ``filename`` via e.g. ``echo '$text' >> $filename``.
+    If ``text`` is already found in ``filename``, the append is not run and 
+    returns immediately.
+    Otherwise, the given text is appended to the end of the given ``filename``
+    via e.g. ``echo '$text' >> $filename``.
 
     The test for whether ``text`` already exists defaults to a full line match,
     e.g. ``^<text>$``, as this seems to be the most sensible approach for the

--- a/fabric/contrib/files.py
+++ b/fabric/contrib/files.py
@@ -369,8 +369,7 @@ def append(filename, text, use_sudo=False, partial=False, escape=True,
     When a list is given, each string inside is handled independently (but in
     the order given.)
 
-    If ``text`` is already found in ``filename``, the append is not run, and
-    None is returned immediately. Otherwise, the given text is appended to the
+    If ``text`` is already found in ``filename``, the append is not run. Otherwise, the given text is appended to the
     end of the given ``filename`` via e.g. ``echo '$text' >> $filename``.
 
     The test for whether ``text`` already exists defaults to a full line match,


### PR DESCRIPTION
The documentation of the append() method in module fabric.contrib.files (http://docs.fabfile.org/en/1.10/api/contrib/files.html) is misleading.

As the documentation states:
"If text is already found in filename, the append is not run, and None is returned immediately."

It should mention that append() has no return value. So it would return None in any case. This means even appending a text to a file will result in a None in python.