### PR TITLE
Fix Documentation for fabric.contrib.files.append()

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2009-2015 Jeffrey E. Forcier
+Copyright (c) 2009-2016 Jeffrey E. Forcier
 Copyright (c) 2008-2009 Christian Vest Hansen
 All rights reserved.
 

--- a/fabric/contrib/files.py
+++ b/fabric/contrib/files.py
@@ -369,8 +369,10 @@ def append(filename, text, use_sudo=False, partial=False, escape=True,
     When a list is given, each string inside is handled independently (but in
     the order given.)
 
-    If ``text`` is already found in ``filename``, the append is not run. Otherwise, the given text is appended to the
-    end of the given ``filename`` via e.g. ``echo '$text' >> $filename``.
+    If ``text`` is already found in ``filename``, the append is not run and 
+    returns immediately.
+    Otherwise, the given text is appended to the end of the given ``filename``
+    via e.g. ``echo '$text' >> $filename``.
 
     The test for whether ``text`` already exists defaults to a full line match,
     e.g. ``^<text>$``, as this seems to be the most sensible approach for the

--- a/fabric/contrib/files.py
+++ b/fabric/contrib/files.py
@@ -369,8 +369,7 @@ def append(filename, text, use_sudo=False, partial=False, escape=True,
     When a list is given, each string inside is handled independently (but in
     the order given.)
 
-    If ``text`` is already found in ``filename``, the append is not run, and
-    None is returned immediately. Otherwise, the given text is appended to the
+    If ``text`` is already found in ``filename``, the append is not run. Otherwise, the given text is appended to the
     end of the given ``filename`` via e.g. ``echo '$text' >> $filename``.
 
     The test for whether ``text`` already exists defaults to a full line match,

--- a/fabric/utils.py
+++ b/fabric/utils.py
@@ -30,9 +30,12 @@ def abort(msg):
     """
     Abort execution, print ``msg`` to stderr and exit with error status (1.)
 
-    This function currently makes use of `sys.exit`_, which raises
-    `SystemExit`_. Therefore, it's possible to detect and recover from inner
-    calls to `abort` by using ``except SystemExit`` or similar.
+    This function currently makes use of `SystemExit`_ in a manner that is
+    similar to `sys.exit`_ (but which skips the automatic printing to stderr,
+    allowing us to more tightly control it via settings).
+
+    Therefore, it's possible to detect and recover from inner calls to `abort`
+    by using ``except SystemExit`` or similar.
 
     .. _sys.exit: http://docs.python.org/library/sys.html#sys.exit
     .. _SystemExit: http://docs.python.org/library/exceptions.html#exceptions.SystemExit
@@ -50,7 +53,13 @@ def abort(msg):
     if env.abort_exception:
         raise env.abort_exception(msg)
     else:
-        sys.exit(msg)
+        # See issue #1318 for details on the below; it lets us construct a
+        # valid, useful SystemExit while sidestepping the automatic stderr
+        # print (which would otherwise duplicate with the above in a
+        # non-controllable fashion).
+        e = SystemExit(1)
+        e.message = msg
+        raise e
 
 
 def warn(msg):

--- a/sites/shared_conf.py
+++ b/sites/shared_conf.py
@@ -18,7 +18,6 @@ html_theme_options = {
     'github_user': 'fabric',
     'github_repo': 'fabric',
     'travis_button': True,
-    'gratipay_user': 'bitprophet',
     'analytics_id': 'UA-18486793-1',
 
     'link': '#3782BE',

--- a/sites/www/changelog.rst
+++ b/sites/www/changelog.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+* :bug:`1318` Update functionality added in :issue:`1213` so abort error
+  messages don't get printed twice (once by us, once by ``sys.exit``) but the
+  annotated exception error message is retained. Thanks to Felix Almeida for
+  the report.
 * :bug:`1305` (also :issue:`1313`) Fix a couple minor issues with the operation
   of & demo code for the ``JobQueue`` class. Thanks to ``@dioh`` and Horst
   Gutmann for the report & Cameron Lane for the patch.

--- a/sites/www/roadmap.rst
+++ b/sites/www/roadmap.rst
@@ -28,8 +28,11 @@ While 1.x moves on as above, we are working on a reimagined 2.x version of the
 tool, and plan to:
 
 * Finish and release `the Invoke tool/library
-  <https://github.com/pyinvoke/invoke>`_ (see also :issue:`565`), which is a
-  revamped and standalone version of Fabric's task running components. 
+  <https://github.com/pyinvoke/invoke>`_ (see also :issue:`565` and `this
+  Invoke FAQ
+  <http://www.pyinvoke.org/faq.html#why-was-invoke-split-off-from-the-fabric-project>`_),
+  which is a revamped and standalone version of Fabric's task running
+  components.
 
     * As of early 2015, Invoke is already reasonably mature and has a handful of
       features lacking in Fabric itself, including but not limited to:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -73,7 +73,6 @@ def test_abort_with_exception():
     with settings(abort_exception=TestException):
         abort("Test")
 
-
 @mock_streams('stderr')
 @with_patched_object(output, 'aborts', True)
 def test_abort_message():
@@ -98,7 +97,20 @@ def test_abort_message_only_printed_once():
         result = local("fab -f tests/support/aborts.py kaboom", capture=True)
     # When error in #1318 is present, this has an extra "It burns!" at end of
     # stderr string.
-    eq_(result.stderr, "Fatal error: It burns!\n\nAborting.\n")
+    eq_(result.stderr, "Fatal error: It burns!\n\nAborting.")
+
+@mock_streams('stderr')
+@with_patched_object(output, 'aborts', True)
+def test_abort_exception_contains_separate_message_and_code():
+    """
+    abort()'s SystemExit contains distinct .code/.message attributes.
+    """
+    # Re #1318 / #1213
+    try:
+        abort("Test")
+    except SystemExit as e:
+        eq_(e.message, "Test")
+        eq_(e.code, 1)
 
 @mock_streams('stdout')
 def test_puts_with_user_output_on():


### PR DESCRIPTION
The documentation of the append() method in module fabric.contrib.files (http://docs.fabfile.org/en/1.10/api/contrib/files.html) is misleading.

As the documentation states:
"If text is already found in filename, the append is not run, and None is returned immediately."

It should mention that append() has no return value. So it would return None in any case. This means even appending a text to a file will result in a None in python.