### PR TITLE
Update relative import

### DIFF
--- a/fabric/network.py
+++ b/fabric/network.py
@@ -396,7 +396,7 @@ def connect(user, host, port, cache, seek_gateway=True):
         Whether to try setting up a gateway socket for this connection. Used so
         the actual gateway connection can prevent recursion.
     """
-    from state import env, output
+    from fabric.state import env, output
 
     #
     # Initialization


### PR DESCRIPTION
This line, when Fabric is used with a plugin architecture that re-writes Python's internal import mechanism, results in a stack trace.

Making this line consistent with the rest of the codebase solves this issue.