### PR TITLE
Handle "Server '' not found in known_hosts exception

### DIFF
--- a/fabric/network.py
+++ b/fabric/network.py
@@ -525,6 +525,12 @@ def connect(user, host, port, cache, seek_gateway=True):
                 and not is_key_load_error(e):
                 raise NetworkError(msg, e)
 
+            # Paramiko raises SSHException when host not found in known_hosts
+            # (missing or not supported cert)
+            if e.__class__ is ssh.SSHException \
+                and msg == "Server '%s' not found in known_hosts" % host:
+                raise NetworkError(msg, e)
+
             # Otherwise, assume an auth exception, and prompt for new/better
             # password.
 

--- a/sites/www/changelog.rst
+++ b/sites/www/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :bug:`1458` Correct the message when host is not found in known hosts
+  and ``reject_unknown_host`` and ``abort_on_prompts`` are enabled.
 * :bug:`1447` Fix a relative import in ``fabric.network`` to be
   correctly/consistently absolute instead. Thanks to ``@bildzeitung`` for catch
   & patch.

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -546,6 +546,22 @@ class TestConnections(FabricTest):
         with settings(hide('everything'), skip_bad_hosts=True):
             execute(subtask, hosts=['nope.nonexistent.com'])
 
+    @server()
+    def test_host_not_in_known_hosts_exception(self):
+        """
+        Check reject_unknown_hosts exception
+        """
+        with settings(hide('everything'), reject_unknown_hosts=True,
+                      disable_known_hosts=True, abort_on_prompts=True):
+            try:
+                run("echo foo")
+            except fabric.network.NetworkError as exc:
+                exp = "Server '[127.0.0.1]:2200' not found in known_hosts"
+                assert str(exc) == exp, "%s != %s" % (exc, exp)
+            else:
+                raise AssertionError("Host connected without valid "
+                                     "fingerprint.")
+
 
 @parallel
 def parallel_subtask():


### PR DESCRIPTION
The message with "reject_unknown_hosts" and "abort_on_prompts" is rather
missleading as paramiko returns:

    SSHException: Server 'localhost' not found in known_hosts

but fabric reports:

    Needed to prompt for a connection or sudo password (host:
    localhost), but abort-on-prompts was set to True

This patch handles the special case similarly to existing workarounds.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>