### PR TITLE
Handle Fabric-level assumptions about PyCrypto's use

### DIFF
--- a/fabric/decorators.py
+++ b/fabric/decorators.py
@@ -6,7 +6,10 @@ from __future__ import with_statement
 import types
 from functools import wraps
 
-from Crypto import Random
+try:
+    from Crypto import Random
+except ImportError:
+    Random = None
 
 from fabric import tasks
 from .context_managers import settings
@@ -177,7 +180,8 @@ def parallel(pool_size=None):
             # Required for ssh/PyCrypto to be happy in multiprocessing
             # (as far as we can tell, this is needed even with the extra such
             # calls in newer versions of paramiko.)
-            Random.atfork()
+            if Random:
+                Random.atfork()
             return func(*args, **kwargs)
         inner.parallel = True
         inner.serial = False


### PR DESCRIPTION
This is in prep for bumping the paramiko dependency, where Cryptography is used instead of PyCrypto.
