### PR TITLE
cleanup imports

### DIFF
--- a/tests/server.py
+++ b/tests/server.py
@@ -1,16 +1,11 @@
 from __future__ import with_statement
 
-import copy
-import itertools
 import os
 import re
 import socket
-import stat
-import sys
 import threading
 import time
 import types
-from StringIO import StringIO
 from functools import wraps
 from Python26SocketServer import BaseRequestHandler, ThreadingMixIn, TCPServer
 

--- a/tests/test_contrib.py
+++ b/tests/test_contrib.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import with_statement
-from fabric.operations import local
 import os
 
-from fabric.api import hide, get, show
+from fabric.api import hide, get
 from fabric.contrib.files import upload_template, contains
 from fabric.context_managers import lcd
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,11 +3,9 @@ from __future__ import with_statement
 import copy
 from functools import partial
 from operator import isMappingType
-import os
 import sys
-from contextlib import contextmanager
 
-from fudge import Fake, patched_context, with_fakes
+from fudge import Fake, patched_context
 from nose.tools import ok_, eq_
 
 from fabric.decorators import hosts, roles, task
@@ -16,11 +14,10 @@ from fabric.main import (parse_arguments, _escape_split,
         load_fabfile as _load_fabfile, list_commands, _task_names,
         COMMANDS_HEADER, NESTED_REMINDER)
 import fabric.state
-from fabric.state import _AttributeDict
 from fabric.tasks import Task, WrappedCallableTask
 from fabric.task_utils import _crawl, crawl, merge
 
-from utils import mock_streams, eq_, FabricTest, fabfile, path_prefix, aborts
+from utils import FabricTest, fabfile, path_prefix, aborts
 
 
 # Stupid load_fabfile wrapper to hide newly added return value.

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -1,28 +1,25 @@
 from __future__ import with_statement
 
-from datetime import datetime
-import copy
-import getpass
 import sys
 
-from nose.tools import with_setup, ok_, raises
-from fudge import (Fake, clear_calls, clear_expectations, patch_object, verify,
-    with_patched_object, patched_context, with_fakes)
+from nose.tools import ok_
+from fudge import (Fake, patch_object, with_patched_object, patched_context,
+                   with_fakes)
 
 from fabric.context_managers import settings, hide, show
 from fabric.network import (HostConnectionCache, join_host_strings, normalize,
-    denormalize, key_filenames, ssh)
-from fabric.io import output_loop
-import fabric.network  # So I can call patch_object correctly. Sigh.
+                            denormalize, key_filenames, ssh)
 from fabric.state import env, output, _get_system_username
 from fabric.operations import run, sudo, prompt
 from fabric.tasks import execute
 from fabric.api import parallel
-from fabric import utils # for patching
+from fabric import utils  # for patching
 
-from utils import *
-from server import (server, PORT, RESPONSES, PASSWORDS, CLIENT_PRIVKEY, USER,
-    CLIENT_PRIVKEY_PASSPHRASE)
+from mock_streams import mock_streams
+from server import (server, RESPONSES, PASSWORDS, CLIENT_PRIVKEY, USER,
+                    CLIENT_PRIVKEY_PASSPHRASE)
+from utils import (FabricTest, aborts, assert_contains, eq_, password_response,
+                   patched_input, support)
 
 
 #

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -1,11 +1,17 @@
 from __future__ import with_statement
 
+import os
+import re
+import shutil
+import sys
+
 from contextlib import nested
 from StringIO import StringIO
 
-from nose.tools import ok_
-from fudge import with_fakes, Fake
+from nose.tools import ok_, raises
+from fudge import patched_context, with_fakes, Fake
 from fudge.inspector import arg as fudge_arg
+from mock_streams import mock_streams
 from paramiko.sftp_client import SFTPClient  # for patching
 
 from fabric.state import env, output
@@ -14,10 +20,12 @@ from fabric.operations import require, prompt, _sudo_prefix, _shell_wrap, \
 from fabric.api import get, put, hide, show, cd, lcd, local, run, sudo, quiet
 from fabric.exceptions import CommandTimeout
 
+from fabric.sftp import SFTP
+from fabric.context_managers import settings
 from fabric.decorators import with_settings
-from utils import *
-from server import (server, PORT, RESPONSES, FILES, PASSWORDS, CLIENT_PRIVKEY,
-    USER, CLIENT_PRIVKEY_PASSPHRASE)
+from utils import (eq_, aborts, assert_contains, eq_contents,
+                   with_patched_input, FabricTest)
+from server import server, FILES
 
 #
 # require()

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,6 +1,5 @@
 from __future__ import with_statement
 
-from contextlib import contextmanager
 from fudge import Fake, patched_context, with_fakes
 import unittest
 from nose.tools import eq_, raises, ok_
@@ -11,10 +10,9 @@ import fabric
 from fabric.tasks import WrappedCallableTask, execute, Task, get_task_details
 from fabric.main import display_command
 from fabric.api import run, env, settings, hosts, roles, hide, parallel, task, runs_once, serial
-from fabric.network import from_dict
 from fabric.exceptions import NetworkError
 
-from utils import eq_, FabricTest, aborts, mock_streams, support
+from utils import FabricTest, aborts, mock_streams, support
 from server import server
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,14 +1,13 @@
 from __future__ import with_statement
 
 import sys
-import traceback
 from unittest import TestCase
 
 from fudge import Fake, patched_context, with_fakes
 from fudge.patcher import with_patched_object
 from nose.tools import eq_, raises
 
-from fabric.state import output, env
+from fabric.state import output
 from fabric.utils import warn, indent, abort, puts, fastprint, error, RingBuffer
 from fabric import utils  # For patching
 from fabric.api import local, quiet

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,7 +1,6 @@
 from __future__ import with_statement
 
 from contextlib import contextmanager
-from copy import deepcopy
 from fudge.patcher import with_patched_object
 from functools import partial
 from types import StringTypes
@@ -13,15 +12,12 @@ import shutil
 import sys
 import tempfile
 
-from fudge import Fake, patched_context, clear_expectations, with_patched_object
+from fudge import Fake, patched_context, clear_expectations
 from nose.tools import raises
-from nose import SkipTest
 
-from fabric.context_managers import settings
 from fabric.state import env, output
 from fabric.sftp import SFTP
-import fabric.network
-from fabric.network import normalize, to_dict
+from fabric.network import to_dict
 
 from server import PORT, PASSWORDS, USER, HOST
 from mock_streams import mock_streams


### PR DESCRIPTION
This commit removes unused imports and wildcard imports from the test-suite. So basically just some cleanup.

What the test-suite said after the change:

```
(py2)user@host ~/git/fabric $ python setup.py test
...
test_version.test_get_version('1.0 pre-alpha', '1.0 pre-alpha') ... ok

----------------------------------------------------------------------
Ran 409 tests in 148.870s

OK
```