### PR TITLE
Remove the text about dependencies blocking the migration to Python 3

### DIFF
--- a/sites/www/installing.rst
+++ b/sites/www/installing.rst
@@ -67,7 +67,7 @@ and notes about other Python versions:
 * Fabric has not yet been tested on **Python 3.x** and is thus likely to be
   incompatible with that line of development. However, we try to be at least
   somewhat forward-looking (e.g. using ``print()`` instead of ``print``) and
-  will definitely be porting to 3.x in the future once our dependencies do.
+  will definitely be porting to 3.x in the future.
 
 setuptools
 ----------


### PR DESCRIPTION
Remove `once our dependencies do` because all dependencies are already Python 3 compatible.

https://caniusepython3.com/project/Fabric
