### PR TITLE
Added to the FAQ more details about how to use csh.

### DIFF
--- a/sites/www/faq.rst
+++ b/sites/www/faq.rst
@@ -251,6 +251,12 @@ argument, like so::
 
 This has been shown to work on FreeBSD and may work on other systems as well.
 
+If the remote host uses ``csh`` for your login shell, fabric requires the shell variable
+backslash_quote to be set, or else the quoting will not work. If this is not the default,
+you probably want to add the following line to ``~/.cshrc``::
+
+    set backslash_quote
+
 
 I'm sometimes incorrectly asked for a passphrase instead of a password.
 =======================================================================


### PR DESCRIPTION
There are multiple open issues in github about csh and quoting, also
on StackOverflow and else.

Background:

With normal settings (use_shell=True, shell_escape=True), a command that has
env.env_vars is wrapped and handed to the csh as:

/bin/bash -l -c "export FOO=\"bar\" && actual-command"

If in the csh setting backslash_quote is not set, csh does not handle the \"
as expected, but reads the command line as (one line per arg):

/bin/bash
-l
-c
export FOO=\
bar\
&& actual-command

... and chokes on the final "