### PR TITLE
#1475: pass timeout to transport open_session

### DIFF
--- a/fabric/state.py
+++ b/fabric/state.py
@@ -407,7 +407,8 @@ connections = HostConnectionCache()
 
 
 def _open_session():
-    return connections[env.host_string].get_transport().open_session()
+    t = env.timeout
+    return connections[env.host_string].get_transport().open_session(timeout=t)
 
 
 def default_channel():


### PR DESCRIPTION
Try to fix #1475 passing env.timeout to transport's open_session()
