### PR TITLE
Cross-platform support

### DIFF
--- a/fabric/contrib/files.py
+++ b/fabric/contrib/files.py
@@ -28,11 +28,7 @@ def exists(path, use_sudo=False, verbose=False):
     """
     func = use_sudo and sudo or run
     with settings(hide('everything'), warn_only=True):
-        try:
-            result = func("ver") #is there better way to detect remote windows?
-            cmd = 'stat %s' % (_expand_path(path) if result.failed else path)
-        except:
-            cmd = 'test -e %s' % _expand_path(path)
+        cmd = 'stat %s' % (_expand_path(path) if func("ver").failed else path)
     # If verbose, run normally
     if verbose:
         with settings(warn_only=True):

--- a/fabric/contrib/files.py
+++ b/fabric/contrib/files.py
@@ -27,7 +27,12 @@ def exists(path, use_sudo=False, verbose=False):
     behavior.
     """
     func = use_sudo and sudo or run
-    cmd = 'stat %s' % (_expand_path(path) if func("ver").failed else path)
+    with settings(hide('everything'), warn_only=True):
+        try:
+            result = func("ver") #is there better way to detect remote windows?
+            cmd = 'stat %s' % (_expand_path(path) if result.failed else path)
+        except:
+            cmd = 'test -e %s' % _expand_path(path)
     # If verbose, run normally
     if verbose:
         with settings(warn_only=True):

--- a/fabric/contrib/files.py
+++ b/fabric/contrib/files.py
@@ -27,7 +27,7 @@ def exists(path, use_sudo=False, verbose=False):
     behavior.
     """
     func = use_sudo and sudo or run
-    cmd = 'test -e %s' % _expand_path(path)
+    cmd = 'stat %s' % path
     # If verbose, run normally
     if verbose:
         with settings(warn_only=True):

--- a/fabric/contrib/files.py
+++ b/fabric/contrib/files.py
@@ -27,7 +27,7 @@ def exists(path, use_sudo=False, verbose=False):
     behavior.
     """
     func = use_sudo and sudo or run
-    cmd = 'stat %s' % path
+    cmd = 'stat %s' % (_expand_path(path) if func("ver").failed else path)
     # If verbose, run normally
     if verbose:
         with settings(warn_only=True):

--- a/fabric/contrib/files.py
+++ b/fabric/contrib/files.py
@@ -27,8 +27,7 @@ def exists(path, use_sudo=False, verbose=False):
     behavior.
     """
     func = use_sudo and sudo or run
-    with settings(hide('everything'), warn_only=True):
-        cmd = 'stat %s' % _expand_path(path)
+    cmd = 'stat %s' % _expand_path(path)
     # If verbose, run normally
     if verbose:
         with settings(warn_only=True):

--- a/fabric/contrib/files.py
+++ b/fabric/contrib/files.py
@@ -449,7 +449,7 @@ def is_win():
     Return True if remote SSH server is running Windows OS, False otherwise
 
     The idea is based on echoing quoted text!
-    *NIX systems will echo quote text only,
+    \*NIX systems will echo quote text only,
     while windows echoes quotation marks as well.
     """
     with settings(hide('everything'), warn_only=True):

--- a/fabric/contrib/files.py
+++ b/fabric/contrib/files.py
@@ -25,7 +25,7 @@ def exists(path, use_sudo=False, verbose=False):
     stderr and any warning resulting from the file not existing) in order to
     avoid cluttering output. You may specify ``verbose=True`` to change this
     behavior.
-    
+
     .. versionchanged:: 1.0
         In order to increase the support to Windows as well,
         `test -e` was replaced by `stat` which is
@@ -447,7 +447,7 @@ def _escape_for_regex(text):
 def is_win():
     """
     Return True if remote SSH server is running Windows OS, False otherwise
-    
+
     The idea is based on echoing quoted text!
     *NIX systems will echo quote text only,
     while windows echoes quotation marks as well.
@@ -458,6 +458,7 @@ def is_win():
 def _expand_path(path):
     """
     Return a path expansion
+
     E.g.    ~/some/path     ->  /home/myuser/some/path
             /user/*/share   ->  /user/local/share
     More examples can be found here: http://linuxcommand.org/lc3_lts0080.php

--- a/fabric/contrib/files.py
+++ b/fabric/contrib/files.py
@@ -460,7 +460,7 @@ def _expand_path(path):
     Return a path expansion
 
     E.g.    ~/some/path     ->  /home/myuser/some/path
-            /user/*/share   ->  /user/local/share
+            /user/\*/share   ->  /user/local/share
     More examples can be found here: http://linuxcommand.org/lc3_lts0080.php
 
     .. versionchanged:: 1.0

--- a/fabric/contrib/files.py
+++ b/fabric/contrib/files.py
@@ -25,6 +25,11 @@ def exists(path, use_sudo=False, verbose=False):
     stderr and any warning resulting from the file not existing) in order to
     avoid cluttering output. You may specify ``verbose=True`` to change this
     behavior.
+    
+    .. versionchanged:: 1.0
+        In order to increase the support to Windows as well,
+        `test -e` was replaced by `stat` which is
+        commonly ported to Windows with other GNU tools.
     """
     func = use_sudo and sudo or run
     cmd = 'stat %s' % _expand_path(path)
@@ -439,6 +444,25 @@ def _escape_for_regex(text):
     regex = regex.replace(r"\'", "'")
     return regex
 
-def _expand_path(path):
+def is_win():
+    """
+    Return True if remote SSH server is running Windows OS, False otherwise
+    
+    The idea is based on echoing quoted text!
+    *NIX systems will echo quote text only,
+    while windows echoes quotation marks as well.
+    """
     with settings(hide('everything'), warn_only=True):
-        return path if '"' in run('echo "WinOS echoes quotes"') else '"$(echo %s)"' % path
+        return '"' in run('echo "Will you echo quotation marks?"')
+
+def _expand_path(path):
+    """
+    Return a path expansion
+    E.g.    ~/some/path     ->  /home/myuser/some/path
+            /user/*/share   ->  /user/local/share
+    More examples can be found here: http://linuxcommand.org/lc3_lts0080.php
+
+    .. versionchanged:: 1.0
+        Avoid breaking remote Windows commands which does not support expansion.
+    """
+    return path if is_win() else '"$(echo %s)"' % path

--- a/fabric/contrib/files.py
+++ b/fabric/contrib/files.py
@@ -28,7 +28,7 @@ def exists(path, use_sudo=False, verbose=False):
     """
     func = use_sudo and sudo or run
     with settings(hide('everything'), warn_only=True):
-        cmd = 'stat %s' % (_expand_path(path) if func("ver").failed else path)
+        cmd = 'stat %s' % _expand_path(path)
     # If verbose, run normally
     if verbose:
         with settings(warn_only=True):
@@ -441,4 +441,5 @@ def _escape_for_regex(text):
     return regex
 
 def _expand_path(path):
-    return '"$(echo %s)"' % path
+    with settings(hide('everything'), warn_only=True):
+        return path if '"' in run('echo "WinOS echoes quotes"') else '"$(echo %s)"' % path


### PR DESCRIPTION
Windows can now run OpenSSH server, however, `test` is not provided in portable GNU executables.
As per issue #1496, `stat` would provide a better replacement, especially since it exits in *NIX and Windows GNU portable executables!