### PR TITLE
avoid use of str.format() in network.py

### DIFF
--- a/fabric/network.py
+++ b/fabric/network.py
@@ -472,7 +472,7 @@ def connect(user, host, port, cache, seek_gateway=True):
                 sock=sock,
             )
             for suffix in ('auth', 'deleg_creds', 'kex'):
-                name = 'gss_{0}'.format(suffix)
+                name = "gss_" + suffix
                 val = env.get(name, None)
                 if val is not None:
                     kwargs[name] = val

--- a/sites/www/changelog.rst
+++ b/sites/www/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :bug:`1514` Compatibility with Python 2.5 was broken by using the ``format()``
+  method of a string (only in 1.11+). Report by ``@pedrudehuere``.
 * :release:`1.11.3 <2016-12-05>`
 * :release:`1.10.5 <2016-12-05>`
 * :bug:`1470` When using `~fabric.operations.get` with glob expressions, a lack


### PR DESCRIPTION
fixes #1514 
(restores python2.5 compatibility)

I tested with python2.7 by just running a task which runs commands on a remote server - I'm just assuming, without looking too closely, that this connect() function was called. Also ran "nosetests" - but the change is about as small as they get anyway :)
