### PR TITLE
put() and get(): use random temp file when use_sudo=True

### DIFF
--- a/fabric/sftp.py
+++ b/fabric/sftp.py
@@ -1,10 +1,10 @@
 from __future__ import with_statement
 
-import hashlib
 import os
 import posixpath
 import stat
 import re
+import uuid
 from fnmatch import filter as fnfilter
 
 from fabric.state import output, connections, env
@@ -158,11 +158,7 @@ class SFTP(object):
         # path in the default remote CWD (which, typically, the login user will
         # have write permissions on) in order to sudo(cp) it.
         if use_sudo:
-            target_path = remote_path
-            hasher = hashlib.sha1()
-            hasher.update(env.host_string)
-            hasher.update(target_path)
-            target_path = posixpath.join(temp_dir, hasher.hexdigest())
+            target_path = posixpath.join(temp_dir, uuid.uuid4().hex)
             # Temporarily nuke 'cwd' so sudo() doesn't "cd" its mv command.
             # (The target path has already been cwd-ified elsewhere.)
             with settings(hide('everything'), cwd=""):
@@ -250,10 +246,7 @@ class SFTP(object):
         # have write permissions on) in order to sudo(mv) it later.
         if use_sudo:
             target_path = remote_path
-            hasher = hashlib.sha1()
-            hasher.update(env.host_string)
-            hasher.update(target_path)
-            remote_path = posixpath.join(temp_dir, hasher.hexdigest())
+            remote_path = posixpath.join(temp_dir, uuid.uuid4().hex)
         # Read, ensuring we handle file-like objects correct re: seek pointer
         putter = self.ftp.put
         if not local_is_path:

--- a/sites/www/changelog.rst
+++ b/sites/www/changelog.rst
@@ -2,6 +2,9 @@
 Changelog
 =========
 
+* :bug:`1555` Multiple simultaneous `~fabric.operations.get` and/or
+  `~fabric.operations.put` with ``use_sudo=True`` and for the same remote host
+  and path could fail unnecessarily. Thanks ``@arnimarj`` for the report.
 * :bug:`1427` (via :issue:`1428`) Locate ``.pyc`` files when searching for
   fabfiles to load; previously we only used the presence of ``.py`` files to
   determine whether loading should be attempted. Credit: Ray Chen.

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -763,19 +763,16 @@ class TestFileTransfers(FabricTest):
         """
         get(use_sudo=True) works by copying to a temporary path, downloading it and then removing it at the end
         """
-        # the sha1 hash is the unique filename of the file being downloaded. sha1(<filename>)
-        name = "229a29e5693876645e39de0cb0532e43ad73311a"
         fake_run = Fake('_run_command', callable=True, expect_call=True).with_matching_args(
-            'cp -p "/etc/apache2/apache2.conf" "%s"' % name, True, True, None,
+            fudge_arg.startswith('cp -p "/etc/apache2/apache2.conf" "'), True, True, None
         ).next_call().with_matching_args(
-            'chown username "%s"' % name, True, True, None,
+            fudge_arg.startswith('chown username "'), True, True, None,
         ).next_call().with_matching_args(
-            'chmod 400 "%s"' % name, True, True, None,
+            fudge_arg.startswith('chmod 400 "'), True, True, None,
         ).next_call().with_matching_args(
-            'rm -f "%s"' % name, True, True, None,
+            fudge_arg.startswith('rm -f "'), True, True, None,
         )
-        fake_get = Fake('get', callable=True, expect_call=True).with_args(
-            name, fudge_arg.any_value())
+        fake_get = Fake('get', callable=True, expect_call=True)
 
         with hide('everything'):
             with patched_context('fabric.operations', '_run_command', fake_run):
@@ -788,21 +785,19 @@ class TestFileTransfers(FabricTest):
     @with_fakes
     def test_get_use_sudo_temp_dir(self):
         """
-        get(use_sudo=True, temp_dir="/tmp") works by copying to a /tmp/sha1_hash, downloading it and then removing it at the end
+        get(use_sudo=True, temp_dir="/tmp") works by copying to /tmp/..., downloading it and then removing it at the end
         """
-        # the sha1 hash is the unique filename of the file being downloaded. sha1(<filename>)
-        name = "229a29e5693876645e39de0cb0532e43ad73311a"
         fake_run = Fake('_run_command', callable=True, expect_call=True).with_matching_args(
-            'cp -p "/etc/apache2/apache2.conf" "/tmp/%s"' % name, True, True, None,
+            fudge_arg.startswith('cp -p "/etc/apache2/apache2.conf" "/tmp/'), True, True, None,
         ).next_call().with_matching_args(
-            'chown username "/tmp/%s"' % name, True, True, None,
+            fudge_arg.startswith('chown username "/tmp/'), True, True, None,
         ).next_call().with_matching_args(
-            'chmod 400 "/tmp/%s"' % name, True, True, None,
+            fudge_arg.startswith('chmod 400 "/tmp/'), True, True, None,
         ).next_call().with_matching_args(
-            'rm -f "/tmp/%s"' % name, True, True, None,
+            fudge_arg.startswith('rm -f "/tmp/'), True, True, None,
         )
         fake_get = Fake('get', callable=True, expect_call=True).with_args(
-            '/tmp/%s' % name, fudge_arg.any_value())
+            fudge_arg.startswith('/tmp/'), fudge_arg.any_value())
 
         with hide('everything'):
             with patched_context('fabric.operations', '_run_command', fake_run):
@@ -963,12 +958,10 @@ class TestFileTransfers(FabricTest):
         """
         put(use_sudo=True) works by uploading a the `local_path` to a temporary path and then moving it to a `remote_path`
         """
-        # the sha1 hash is the unique filename of the file being downloaded. sha1(<filename>)
         fake_run = Fake('_run_command', callable=True, expect_call=True).with_matching_args(
-            'mv "7c91837ec0b3570264a325df6b7ef949ee22bc56" "/foobar.txt"', True, True, None,
+            fudge_arg.startswith('mv "'), True, True, None,
         )
-        fake_put = Fake('put', callable=True, expect_call=True).with_args(fudge_arg.any_value(),
-                                                                          '7c91837ec0b3570264a325df6b7ef949ee22bc56')
+        fake_put = Fake('put', callable=True, expect_call=True)
 
         local_path = self.mkfile('foobar.txt', "baz")
         with hide('everything'):
@@ -986,10 +979,9 @@ class TestFileTransfers(FabricTest):
         """
         # the sha1 hash is the unique filename of the file being downloaded. sha1(<filename>)
         fake_run = Fake('_run_command', callable=True, expect_call=True).with_matching_args(
-            'mv "/tmp/7c91837ec0b3570264a325df6b7ef949ee22bc56" "/foobar.txt"', True, True, None,
+            fudge_arg.startswith('mv "'), True, True, None,
         )
-        fake_put = Fake('put', callable=True, expect_call=True).with_args(fudge_arg.any_value(),
-                                                                          '/tmp/7c91837ec0b3570264a325df6b7ef949ee22bc56')
+        fake_put = Fake('put', callable=True, expect_call=True)
 
         local_path = self.mkfile('foobar.txt', "baz")
         with hide('everything'):


### PR DESCRIPTION
This was using a hash of the host and remote file path,
and could result in an unnecessary failure if there were
multiple get() and/or put() of the same file path on the same host
simultaneously.

fixes #1555