### PR TITLE
fix _escape_for_regex() for contrib.files.append() / contains()

### DIFF
--- a/fabric/contrib/files.py
+++ b/fabric/contrib/files.py
@@ -5,7 +5,6 @@ Module providing easy API for working with remote files and folders.
 from __future__ import with_statement
 
 import hashlib
-import re
 import os
 from StringIO import StringIO
 from functools import partial
@@ -337,7 +336,7 @@ def contains(filename, text, exact=False, use_sudo=False, escape=True,
     added.)
 
     The ``shell`` argument will be eventually passed to ``run/sudo``. See
-    description of the same argumnet in ``~fabric.contrib.sed`` for details.
+    description of the same argument in ``~fabric.contrib.sed`` for details.
 
     .. versionchanged:: 1.0
         Swapped the order of the ``filename`` and ``text`` arguments to be
@@ -413,14 +412,22 @@ def append(filename, text, use_sudo=False, partial=False, escape=True,
 
 def _escape_for_regex(text):
     """Escape ``text`` to allow literal matching using egrep"""
-    regex = re.escape(text)
-    # Seems like double escaping is needed for \
-    regex = regex.replace('\\\\', '\\\\\\')
-    # Triple-escaping seems to be required for $ signs
-    regex = regex.replace(r'\$', r'\\\$')
-    # Whereas single quotes should not be escaped
-    regex = regex.replace(r"\'", "'")
-    return regex
+    re_specials = '\\^$|(){}[]*+?.'
+    sh_specials = '\\$`"'
+    re_chars = []
+    sh_chars = []
+
+    for c in text:
+        if c in re_specials:
+            re_chars.append('\\')
+        re_chars.append(c)
+
+    for c in re_chars:
+        if c in sh_specials:
+            sh_chars.append('\\')
+        sh_chars.append(c)
+
+    return ''.join(sh_chars)
 
 def _expand_path(path):
     return '"$(echo %s)"' % path

--- a/sites/www/changelog.rst
+++ b/sites/www/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :bug:`1294` fix text escaping for `~fabric.contrib.files.contains` and
+  `~fabric.contrib.files.append` which would fail if the text contained e.g. ``>``
 * :support:`1539` Add documentation for :ref:`env.output_prefix <output_prefix>`. Thanks ``@jphalip``.
 * :release:`1.10.5 <2016-12-05>`
 * :bug:`1470` When using `~fabric.operations.get` with glob expressions, a lack


### PR DESCRIPTION
`_escape_for_regex()` is supposed to escape for egrep run by a shell.
python's `re.escape()` is not really close to doing what's needed, so re-implement.

fixes #1294 
alternative to #1323 which is a bit crazy

tested with:

`test.txt`:
```
testing123
 +*^$&1[({\0
some"$HOST'stuff
over > rainbow
in | the|<sky `high`
```

`fabfile.py`:
```python
from fabric.api import task, run, sudo
from fabric.contrib.files import contains, append

@task
def test():
    run("cat test.txt")

    for pat in [
        "testing",
        "testing123",
        "testing.23",
        " +*^$",
        " +*^$&1[({\\0",
        ".+*^$&1[({\\0",
        "\"$HOST\'",
        "over > rainbow",
        "|sky `high`",
    ]:
        r1 = contains("test.txt", pat)
        r2 = contains("test.txt", pat, exact=True)
        print("pat='%s' contains=%r exact=%r" % (pat, r1, r2))
        r3 = contains("test.txt", pat, use_sudo=True)
        r4 = contains("test.txt", pat, use_sudo=True, exact=True)
        if r3 != r1 or r4 != r2:
            print("sudo result diff contains=%r exact=%r" % (r3, r4))

    append("test.txt", "testing123")
    append("test.txt", "testing.23") # should be added
    append("test.txt", " +*^$&1[({\\0")
    append("test.txt", " +*^$&1[(", partial=True)
    append("test.txt", " +*^$&1[({\\!", partial=True)  # should be added
    append("test.txt", "over > rainbow")
    append("test.txt", "in | the|", partial=True)
    append("test.txt", "in|the|<sky`high`")        # should be added
    append("test.txt", " +*^$&1[({\\0", use_sudo=True)
    append("test.txt", " +*^$&1[({\\3", use_sudo=True) # should be added

    run("cat test.txt")
```

results as expected:

```
(venv) [pierce@plo-pro fabwork]$ fab -H testdeploy03.ec2.st-av.net test
[testdeploy03.ec2.st-av.net] Executing task 'test'
[testdeploy03.ec2.st-av.net] run: cat test.txt
[testdeploy03.ec2.st-av.net] out: testing123
[testdeploy03.ec2.st-av.net] out:  +*^$&1[({\0
[testdeploy03.ec2.st-av.net] out: some"$HOST'stuff
[testdeploy03.ec2.st-av.net] out: over > rainbow
[testdeploy03.ec2.st-av.net] out: in | the|<sky `high`
[testdeploy03.ec2.st-av.net] out: 

pat='testing' contains=True exact=False
pat='testing123' contains=True exact=True
pat='testing.23' contains=False exact=False
pat=' +*^$' contains=True exact=False
pat=' +*^$&1[({\0' contains=True exact=True
pat='.+*^$&1[({\0' contains=False exact=False
pat='"$HOST'' contains=True exact=False
pat='over > rainbow' contains=True exact=True
pat='|sky `high`' contains=False exact=False
[testdeploy03.ec2.st-av.net] run: echo 'testing.23' >> "$(echo test.txt)"
[testdeploy03.ec2.st-av.net] run: echo ' +*^$&1[({\!' >> "$(echo test.txt)"
[testdeploy03.ec2.st-av.net] run: echo 'in|the|<sky`high`' >> "$(echo test.txt)"
[testdeploy03.ec2.st-av.net] sudo: echo ' +*^$&1[({\3' >> "$(echo test.txt)"
[testdeploy03.ec2.st-av.net] run: cat test.txt
[testdeploy03.ec2.st-av.net] out: testing123
[testdeploy03.ec2.st-av.net] out:  +*^$&1[({\0
[testdeploy03.ec2.st-av.net] out: some"$HOST'stuff
[testdeploy03.ec2.st-av.net] out: over > rainbow
[testdeploy03.ec2.st-av.net] out: in | the|<sky `high`
[testdeploy03.ec2.st-av.net] out: testing.23
[testdeploy03.ec2.st-av.net] out:  +*^$&1[({\!
[testdeploy03.ec2.st-av.net] out: in|the|<sky`high`
[testdeploy03.ec2.st-av.net] out:  +*^$&1[({\3
[testdeploy03.ec2.st-av.net] out: 


Done.
Disconnecting from testdeploy03.ec2.st-av.net... done.
```

I admittedly did not test with `shell=True` - I'm not even sure what should happen in that case. But what's here is probably a big improvement for a minimal changeset.