### PR TITLE
contrib.sed(): avoid shell for uname

### DIFF
--- a/fabric/contrib/files.py
+++ b/fabric/contrib/files.py
@@ -227,7 +227,7 @@ def sed(filename, before, after, limit='', use_sudo=False, backup='.bak',
     # Test the OS because of differences between sed versions
 
     with hide('running', 'stdout'):
-        platform = run("uname")
+        platform = run("uname", shell=False, pty=False)
     if platform in ('NetBSD', 'OpenBSD', 'QNX'):
         # Attempt to protect against failures/collisions
         hasher = hashlib.sha1()


### PR DESCRIPTION
Some (uncommon) systems can end up with shell escapes in the output
of run("uname"), so don't use shell (or pty), they're not needed anyway.

fixes #1526 / #1527

Figured this was another very easy little "fix". I'm happy to re-target to whatever branch is desired.

There is an integration test for `contrib.sed()` (already), which should be a reasonable sanity-test that I didn't break it...