### PR TITLE
fix upload_project() for local_dir with no path separator

### DIFF
--- a/fabric/contrib/project.py
+++ b/fabric/contrib/project.py
@@ -186,6 +186,7 @@ def upload_project(local_dir=None, remote_dir="", use_sudo=False):
     local_dir = local_dir.rstrip(os.sep)
 
     local_path, local_name = os.path.split(local_dir)
+    local_path = local_path or '.'
     tar_file = "%s.tar.gz" % local_name
     target_tar = os.path.join(remote_dir, tar_file)
     tmp_folder = mkdtemp()

--- a/sites/www/changelog.rst
+++ b/sites/www/changelog.rst
@@ -2,6 +2,9 @@
 Changelog
 =========
 
+* :bug:`1574` `~fabric.contrib.project.upload_project` failed for folder in
+  current directory specified without any path separator. Thanks ``@aidanmelen``
+  for the report and Pierce Lopez for the patch.
 * :support:`1539` Add documentation for :ref:`env.output_prefix <output_prefix>`. Thanks ``@jphalip``.
 * :release:`1.10.5 <2016-12-05>`
 * :bug:`1470` When using `~fabric.operations.get` with glob expressions, a lack

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -104,7 +104,23 @@ class UploadProjectTestCase(unittest.TestCase):
         # local() is called more than once so we need an extra next_call()
         # otherwise fudge compares the args to the last call to local()
         self.fake_local.with_args(
-            arg.endswith("-C %s %s" % os.path.split(project_path))
+            arg.endswith("-C path/to/my project")
+        ).next_call()
+
+        # Exercise
+        project.upload_project(local_dir=project_path)
+
+
+    @fudge.with_fakes
+    def test_path_to_local_project_no_separator(self):
+        """Local folder can have no path separator (in current directory)."""
+
+        project_path = "testpath"
+
+        # local() is called more than once so we need an extra next_call()
+        # otherwise fudge compares the args to the last call to local()
+        self.fake_local.with_args(
+            arg.endswith("-C . testpath")
         ).next_call()
 
         # Exercise


### PR DESCRIPTION
A tiny fix for a contrib function. Bug identified in #1574 

My thinking is: fabric probably does not want to maintain these contrib functions, and will remove them in 2.0+, and I personally don't use them. But if there is a very easy fix for a very simple case, might as well put it in and avoid some bug reports.

The root of the problem here is `os.path.split()` can return a blank parent path, which doesn't work here.

```
>>> os.path.split("./testdir")
('.', 'testdir')
>>> os.path.split("testdir")
('', 'testdir')
```

In addition to the (trivial) unit test, I did a manual test without and with the fix.

before:

```
$ fab -H ubuntu@devbox test
[ubuntu@devbox] Executing task 'test'
[localhost] local: tar -czf /var/folders/ny/tsl8z9qx453630cxnzw0_dj80000gn/T/tmp52uz2D/testdir.tar.gz -C  testdir
tar: no files or directories specified

Fatal error: local() encountered an error (return code 1) while executing 'tar -czf /var/folders/ny/tsl8z9qx453630cxnzw0_dj80000gn/T/tmp52uz2D/testdir.tar.gz -C  testdir'
```

after:

```
$ fab -H ubuntu@devbox test
[ubuntu@devbox] Executing task 'test'
[localhost] local: tar -czf /var/folders/ny/tsl8z9qx453630cxnzw0_dj80000gn/T/tmpatuzuo/testdir.tar.gz -C . testdir
[ubuntu@devbox] put: /var/folders/ny/tsl8z9qx453630cxnzw0_dj80000gn/T/tmpatuzuo/testdir.tar.gz -> /tmp/testdir.tar.gz
[ubuntu@devbox] run: tar -xzf testdir.tar.gz
[ubuntu@devbox] run: rm -f testdir.tar.gz
[localhost] local: rm -rf /var/folders/ny/tsl8z9qx453630cxnzw0_dj80000gn/T/tmpatuzuo
```

I can re-base this on an older branch (e.g. 1.11) and add a changelog entry if desired.