### PR TITLE
Use `python -m fabric` rather than `fab` in tests.

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -93,7 +93,7 @@ def test_abort_message_only_printed_once():
     # perform when they are allowed to bubble all the way to the top. So, we
     # invoke a subprocess and look at its stderr instead.
     with quiet():
-        result = local("fab -f tests/support/aborts.py kaboom", capture=True)
+        result = local("python -m fabric -f tests/support/aborts.py kaboom", capture=True)
     # When error in #1318 is present, this has an extra "It burns!" at end of
     # stderr string.
     eq_(result.stderr, "Fatal error: It burns!\n\nAborting.")


### PR DESCRIPTION
The `test_abort_message_only_printed_once` test needs Fabric already installed to run, since the `fab` executable is created only during install. This wouldn't ordinarily be a problem, but when packaging Fabric for a system like GNU Guix, we'd like to be able to run the tests before installing.

This change switches this single use of `fab` to the equivalent `python -m fabric`.