### PR TITLE
Implement execute() for Groups

### DIFF
--- a/fabric/group.py
+++ b/fabric/group.py
@@ -195,7 +195,6 @@ class ThreadingGroup(Group):
         results = GroupResult()
         queue = Queue()
         threads = []
-        old_configs = {}
         for cxn in self:
             my_kwargs = dict(
                 cxn=cxn,

--- a/tests/group.py
+++ b/tests/group.py
@@ -291,4 +291,3 @@ class ThreadingGroup_(Spec):
                 err = "Expected {0} calls to ExceptionHandlingThread.{1}, got {2}" # noqa
                 err = err.format(expected, name, got)
                 eq_(expected, got, err)
-


### PR DESCRIPTION
This implements the execute method of SerialGroup and ThreadingGroup.

I only wrote one test for now, as I'm not sure this implementation is the best approach and wanted feedback before I continued with reimplementing things like the executor to use these functions.

This implementation modifies each `connection`'s config to include those config variables normally passed as keyword arguments to `connection.run()`.  This gives us keyword control and lets the task's internal logic override us as necessary.  The cloned config is restored after execution (not sure this is the right approach here either).

I needed this functionality to begin implementing fabric/fabric#1594