### PR TITLE
Python 3.6 compatibility; tested with `fab -h` only.

### DIFF
--- a/fabric/contrib/files.py
+++ b/fabric/contrib/files.py
@@ -6,8 +6,12 @@ from __future__ import with_statement
 
 import hashlib
 import os
-from StringIO import StringIO
 from functools import partial
+
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 from fabric.api import run, sudo, hide, settings, env, put, abort
 from fabric.utils import apply_lcwd

--- a/fabric/job_queue.py
+++ b/fabric/job_queue.py
@@ -6,9 +6,14 @@ items, though within Fabric itself only ``Process`` objects are used/supported.
 """
 
 from __future__ import with_statement
+
 import time
-import Queue
 from multiprocessing import Process
+
+try:
+    import Queue
+except ImportError:
+    from queue import Queue
 
 from fabric.network import ssh
 from fabric.context_managers import settings

--- a/fabric/main.py
+++ b/fabric/main.py
@@ -10,11 +10,19 @@ to individuals leveraging Fabric as a library, should be kept elsewhere.
 """
 import getpass
 import inspect
-from operator import isMappingType
-from optparse import OptionParser
 import os
 import sys
 import types
+from optparse import OptionParser
+
+try:
+    from operator import isMappingType
+except ImportError:
+    import collections
+    isMappingType = lambda obj: isinstance(obj, collections.Mapping)
+
+if not hasattr(__builtins__, 'reduce'):
+    from functools import reduce
 
 # For checking callables against the API, & easy mocking
 from fabric import api, state, colors
@@ -30,7 +38,7 @@ from fabric.utils import abort, indent, warn, _pty_size
 # One-time calculation of "all internal callables" to avoid doing this on every
 # check of a given fabfile callable (in is_classic_task()).
 _modules = [api, project, files, console, colors]
-_internals = reduce(lambda x, y: x + filter(callable, vars(y).values()),
+_internals = reduce(lambda x, y: x + list(filter(callable, vars(y).values())),
     _modules,
     []
 )

--- a/fabric/network.py
+++ b/fabric/network.py
@@ -11,7 +11,10 @@ import re
 import time
 import socket
 import sys
-from StringIO import StringIO
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 
 from fabric.auth import get_password, set_password
@@ -22,7 +25,7 @@ try:
     import warnings
     warnings.simplefilter('ignore', DeprecationWarning)
     import paramiko as ssh
-except ImportError, e:
+except ImportError as e:
     import traceback
     traceback.print_exc()
     msg = """
@@ -89,7 +92,7 @@ def get_gateway(host, port, cache, replace=False):
         # ensure initial gateway connection
         if replace or gateway not in cache:
             if output.debug:
-                print "Creating new gateway connection to %r" % gateway
+                print("Creating new gateway connection to %r" % gateway)
             cache[gateway] = connect(*normalize(gateway) + (cache, False))
         # now we should have an open gw connection and can ask it for a
         # direct-tcpip channel to the real target. (bypass cache's own
@@ -243,7 +246,7 @@ def key_from_env(passphrase=None):
                 sys.stderr.write("Trying to load it as %s\n" % pkey_class)
             try:
                 return pkey_class.from_private_key(StringIO(env.key), passphrase)
-            except Exception, e:
+            except Exception as e:
                 # File is valid key, but is encrypted: raise it, this will
                 # cause cxn loop to prompt for passphrase & retry
                 if 'Private key file is encrypted' in e:
@@ -489,14 +492,14 @@ def connect(user, host, port, cache, seek_gateway=True):
         # BadHostKeyException corresponds to key mismatch, i.e. what on the
         # command line results in the big banner error about man-in-the-middle
         # attacks.
-        except ssh.BadHostKeyException, e:
+        except ssh.BadHostKeyException as e:
             raise NetworkError("Host key for %s did not match pre-existing key! Server's key was changed recently, or possible man-in-the-middle attack." % host, e)
         # Prompt for new password to try on auth failure
         except (
             ssh.AuthenticationException,
             ssh.PasswordRequiredException,
             ssh.SSHException
-        ), e:
+        ) as e:
             msg = str(e)
             # If we get SSHExceptionError and the exception message indicates
             # SSH protocol banner read failures, assume it's caused by the
@@ -577,11 +580,11 @@ def connect(user, host, port, cache, seek_gateway=True):
             print('')
             sys.exit(0)
         # Handle DNS error / name lookup failure
-        except socket.gaierror, e:
+        except socket.gaierror as e:
             raise NetworkError('Name lookup failed for %s' % host, e)
         # Handle timeouts and retries, including generic errors
         # NOTE: In 2.6, socket.error subclasses IOError
-        except socket.error, e:
+        except socket.error as e:
             not_timeout = type(e) is not socket.timeout
             giving_up = _tried_enough(tries)
             # Baseline error msg for when debug is off

--- a/fabric/operations.py
+++ b/fabric/operations.py
@@ -217,7 +217,7 @@ def prompt(text, key=None, default='', validate=None):
                 # fails.
                 try:
                     value = validate(value)
-                except Exception, e:
+                except Exception as e:
                     # Reset value so we stay in the loop
                     value = None
                     print("Validation failed for the following reason:")
@@ -398,7 +398,7 @@ def put(local_path=None, remote_path=None, use_sudo=False,
                     p = ftp.put(lpath, remote_path, use_sudo, mirror_local_mode,
                         mode, local_is_path, temp_dir)
                     remote_paths.append(p)
-            except Exception, e:
+            except Exception as e:
                 msg = "put() encountered an exception while uploading '%s'"
                 failure = lpath if local_is_path else "<StringIO>"
                 failed_local_paths.append(failure)
@@ -586,7 +586,7 @@ def get(remote_path, local_path=None, use_sudo=False, temp_dir=""):
                     if local_is_path:
                         local_files.append(result)
 
-        except Exception, e:
+        except Exception as e:
             failed_remote_files.append(remote_path)
             msg = "get() encountered an exception while downloading '%s'"
             error(message=msg % remote_path, exception=e)

--- a/fabric/sftp.py
+++ b/fabric/sftp.py
@@ -82,7 +82,7 @@ class SFTP(object):
             # Note that listdir and error are globals in this module due to
             # earlier import-*.
             names = self.ftp.listdir(top)
-        except Exception, err:
+        except Exception as err:
             if onerror is not None:
                 onerror(err)
             return
@@ -166,7 +166,7 @@ class SFTP(object):
                 # The user should always own the copied file.
                 sudo('chown %s "%s"' % (env.user, target_path))
                 # Only root and the user has the right to read the file
-                sudo('chmod %o "%s"' % (0400, target_path))
+                sudo('chmod %o "%s"' % (int('0400', base=8), target_path))
                 remote_path = target_path
 
         try:
@@ -262,11 +262,11 @@ class SFTP(object):
             # Cast to octal integer in case of string
             if isinstance(lmode, basestring):
                 lmode = int(lmode, 8)
-            lmode = lmode & 07777
+            lmode = lmode & int('07777', base=8)
             rmode = rattrs.st_mode
             # Only bitshift if we actually got an rmode
             if rmode is not None:
-                rmode = (rmode & 07777)
+                rmode = (rmode & int('07777', base=8))
             if lmode != rmode:
                 if use_sudo:
                     # Temporarily nuke 'cwd' so sudo() doesn't "cd" its mv

--- a/fabric/state.py
+++ b/fabric/state.py
@@ -422,7 +422,7 @@ def default_channel():
     """
     try:
         chan = _open_session()
-    except ssh.SSHException, err:
+    except ssh.SSHException as err:
         if str(err) == 'SSH session not active':
             connections[env.host_string].close()
             del connections[env.host_string]

--- a/fabric/tasks.py
+++ b/fabric/tasks.py
@@ -239,7 +239,7 @@ def _execute(task, host, my_env, args, kwargs, jobs, queue, multiprocessing):
             try:
                 state.connections.clear()
                 submit(task.run(*args, **kwargs))
-            except BaseException, e: # We really do want to capture everything
+            except BaseException as e: # We really do want to capture everything
                 # SystemExit implies use of abort(), which prints its own
                 # traceback, host info etc -- so we don't want to double up
                 # on that. For everything else, though, we need to make
@@ -385,7 +385,7 @@ def execute(task, *args, **kwargs):
                     task, host, my_env, args, new_kwargs, jobs, queue,
                     multiprocessing
                 )
-            except NetworkError, e:
+            except NetworkError as e:
                 results[host] = e
                 # Backwards compat test re: whether to use an exception or
                 # abort

--- a/fabric/thread_handling.py
+++ b/fabric/thread_handling.py
@@ -21,5 +21,8 @@ class ThreadHandler(object):
 
     def raise_if_needed(self):
         if self.exception:
-            e = self.exception
-            raise e[0], e[1], e[2]
+            (e_type, e_value, e_tb) = self.exception
+            print('Unexpected exception: {}'.format(e_type))
+            print('Exception value: {!r}'.format(e_value))
+            print('Traceback: {}'.format(e_tb))
+            raise


### PR DESCRIPTION
Quite a few syntactic changes, but functionally speaking, there's potentially a few. Here's a couple worth pointing out.


* Reimplementation of `nested`.
  * https://github.com/sanscore/fabric/blob/71f35201bebeebf4a98b4547b68730d1b53b3875/fabric/context_managers.py#L41-L54
* `raise_if_needed` in `thread_handling.py` uses `raise e[0], e[1], e[2]` which no longer supported. I've never seen `raise` used in that way, so I was unsure of what the modern equivalent is, so I just logged all the values and used a bare `raise` instead.
  * https://github.com/sanscore/fabric/blob/71f35201bebeebf4a98b4547b68730d1b53b3875/fabric/thread_handling.py#L22-L28

It'll be very interesting to see what TravisCI thinks because I cannot get Python2.5 to work on my local machine; `fab -h` works on py26, py27 and py36 without any problems.