### PR TITLE
contrib.files: cache is_win() per host

### DIFF
--- a/fabric/contrib/files.py
+++ b/fabric/contrib/files.py
@@ -449,6 +449,8 @@ def _escape_for_regex(text):
 
     return ''.join(sh_chars)
 
+_is_win_cache = {}
+
 def is_win():
     """
     Return True if remote SSH server is running Windows, False otherwise.
@@ -456,8 +458,11 @@ def is_win():
     The idea is based on echoing quoted text: \*NIX systems will echo quoted
     text only, while Windows echoes quotation marks as well.
     """
-    with settings(hide('everything'), warn_only=True):
-        return '"' in run('echo "Will you echo quotation marks"')
+    if env.host not in _is_win_cache:
+        with settings(hide('everything'), warn_only=True):
+            _is_win_cache[env.host] = '"' in run('echo "test shell quotes"')
+
+    return _is_win_cache[env.host]
 
 def _expand_path(path):
     """


### PR DESCRIPTION
is_win() runs a remote command, and can be called multiple
times for some of the functions in contrib.files, slowing
down execution, and spamming fabric debug output.

example fabfile task:

```python
@task
def test():
    files.append('test.txt', ['127.0.0.1 db', '127.0.0.1 redis'])
```

Before:

```
$ fab --show=debug -H testdeploy11.ec2.st-av.net test
...
[testdeploy11.ec2.st-av.net] Executing task 'test'
[testdeploy11.ec2.st-av.net] run: /bin/bash -l -c "echo \"Will you echo quotation marks\""
[testdeploy11.ec2.st-av.net] run: /bin/bash -l -c "stat \"\$(echo test.txt)\""
[testdeploy11.ec2.st-av.net] run: /bin/bash -l -c "echo \"Will you echo quotation marks\""
[testdeploy11.ec2.st-av.net] run: egrep "^127\\.0\\.0\\.1 db$" "$(echo test.txt)"
[testdeploy11.ec2.st-av.net] run: /bin/bash -l -c "echo \"Will you echo quotation marks\""
[testdeploy11.ec2.st-av.net] run: /bin/bash -l -c "stat \"\$(echo test.txt)\""
[testdeploy11.ec2.st-av.net] run: /bin/bash -l -c "echo \"Will you echo quotation marks\""
[testdeploy11.ec2.st-av.net] run: egrep "^127\\.0\\.0\\.1 redis$" "$(echo test.txt)"
```

After:

```
$ fab --show=debug -H testdeploy11.ec2.st-av.net test
...
[testdeploy11.ec2.st-av.net] Executing task 'test'
[testdeploy11.ec2.st-av.net] run: /bin/bash -l -c "echo \"test shell quotes\""
[testdeploy11.ec2.st-av.net] run: /bin/bash -l -c "stat \"\$(echo test.txt)\""
[testdeploy11.ec2.st-av.net] run: egrep "^127\\.0\\.0\\.1 db$" "$(echo test.txt)"
[testdeploy11.ec2.st-av.net] run: /bin/bash -l -c "stat \"\$(echo test.txt)\""
[testdeploy11.ec2.st-av.net] run: egrep "^127\\.0\\.0\\.1 redis$" "$(echo test.txt)"
```

But, this is probably not the best fix. Instead `_expand_path()` should probably be removed entirely. It doesn't make sense - it only works if the command string is run in a shell, but then the filename could be put in the command string without quotes to get the same expansion treatment.

It looks like it was added in c6a458526c6dad9447c17c3e03e94233a791a715 to fix #367 - but the actual fix is just removing the quotes around the filename argument to egrep. The `_expand_path()` is superfluous.

```diff
@@ -314,7 +314,7 @@ def contains(filename, text, exact=False, use_sudo=False, escape=True,
         if exact:
             text = "^%s$" % text
     with settings(hide('everything'), warn_only=True):
-        egrep_cmd = 'egrep "%s" "%s"' % (text, filename)
+        egrep_cmd = 'egrep "%s" %s' % (text, _expand_path(filename))
         return func(egrep_cmd, shell=shell).succeeded
```

This `_expand_path()` was then applied everywhere in contrib.files "just in case" but it was never needed anywhere, just quotes had to be removed if quoting is not desired (and they're already absent in most places here).

OK, now I've convinced myself that really is the way to go, I might open a pull request to do that. But I didn't want to meddle too much since this is dumb contrib stuff and I don't want to distract from more important things. Too late now I guess.