### PR TITLE
keepalive maps to ServerAliveInterval

### DIFF
--- a/sites/docs/usage/env.rst
+++ b/sites/docs/usage/env.rst
@@ -425,7 +425,7 @@ The global host list used when composing per-task host lists.
 **Default:** ``0`` (i.e. no keepalive)
 
 An integer specifying an SSH keepalive interval to use; basically maps to the
-SSH config option ``ClientAliveInterval``. Useful if you find connections are
+SSH config option ``ServerAliveInterval``. Useful if you find connections are
 timing out due to meddlesome network hardware or what have you.
 
 .. seealso:: :option:`--keepalive`


### PR DESCRIPTION
Currently, the documentation states that keepalive maps to ClientAliveInterval, which is a server side setting, unlike what the name indicates. The client side setting is called ServerAliveInterval. You can see references to this in the below two discussions:

https://github.com/paramiko/paramiko/issues/918
https://unix.stackexchange.com/a/3027/6475