### PR TITLE
[wip] local vs remote task execution (ref #98)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
   # TODO: real test matrix with at least some cells combining different invoke
   # and/or paramiko versions, released versions, etc
   # Invoke from master for parity
-  - "pip install -e git+https://github.com/pyinvoke/invoke#egg=invoke"
+  - "pip install -e git+https://github.com/rpkilby/invoke@context-runner#egg=invoke"
   # And invocations, ditto
   - "pip install -e git+https://github.com/pyinvoke/invocations#egg=invocations"
   # Paramiko ditto

--- a/fabric/__init__.py
+++ b/fabric/__init__.py
@@ -2,4 +2,5 @@
 from ._version import __version_info__, __version__
 from .connection import Config, Connection
 from .runners import Remote, Result
+from .tasks import local_task, task, LocalTask, Task
 from .group import Group, SerialGroup, ThreadingGroup, GroupResult

--- a/fabric/config.py
+++ b/fabric/config.py
@@ -5,7 +5,6 @@ import os
 from invoke.config import Config as InvokeConfig, merge_dicts
 from paramiko.config import SSHConfig
 
-from .runners import Remote
 from .util import get_local_user, debug
 
 
@@ -236,9 +235,6 @@ class Config(InvokeConfig):
             'port': 22,
             'run': {
                 'replace_env': True,
-            },
-            'runners': {
-                'remote': Remote,
             },
             'ssh_config_path': None,
             'tasks': {

--- a/fabric/connection.py
+++ b/fabric/connection.py
@@ -101,6 +101,7 @@ class Connection(Context):
     connect_kwargs = None
     client = None
     transport = None
+    local = None
     _sftp = None
     _agent_handler = None
 
@@ -221,6 +222,10 @@ class Connection(Context):
         # that below. If it's somehow problematic we would want to break parent
         # __init__ up in a manner that is more cleanly overrideable.
         super(Connection, self).__init__(config=config)
+
+        #: A handle for a local Context that allows local commands to be ran
+        #: independently of the Connection's context.
+        self.local = Context(self.config.clone())
 
         #: The .Config object referenced when handling default values (for e.g.
         #: user or port, when not explicitly given) or deciding how to behave.
@@ -572,17 +577,6 @@ class Connection(Context):
         """
         runner = self.config.runners.remote(self)
         return self._sudo(runner, command, **kwargs)
-
-    def local(self, *args, **kwargs):
-        """
-        Execute a shell command on the local system.
-
-        This method is effectively a wrapper of `invoke.run`; see its docs for
-        details and call signature.
-        """
-        # Superclass run() uses runners.local, so we can literally just call it
-        # straight.
-        return super(Connection, self).run(*args, **kwargs)
 
     @opens
     def sftp(self):

--- a/fabric/connection.py
+++ b/fabric/connection.py
@@ -410,6 +410,9 @@ class Connection(BaseContext):
         return hash(self._identity())
 
     def derive_shorthand(self, host_string):
+        if host_string is None:
+            return {'user': '', 'host': '', 'port': ''}
+
         user_hostport = host_string.rsplit('@', 1)
         hostport = user_hostport.pop()
         user = user_hostport[0] if user_hostport and user_hostport[0] else None

--- a/fabric/connection.py
+++ b/fabric/connection.py
@@ -14,6 +14,7 @@ from paramiko.config import SSHConfig
 from paramiko.proxy import ProxyCommand
 
 from .config import Config
+from .runners import Remote
 from .transfer import Transfer
 from .tunnels import TunnelManager, Tunnel
 
@@ -222,6 +223,7 @@ class Connection(Context):
         # that below. If it's somehow problematic we would want to break parent
         # __init__ up in a manner that is more cleanly overrideable.
         super(Connection, self).__init__(config=config)
+        self._set(runner=Remote)
 
         #: A handle for a local Context that allows local commands to be ran
         #: independently of the Connection's context.
@@ -562,8 +564,7 @@ class Connection(Context):
             settings/behaviors; they are documented under
             `.Config.global_defaults`.
         """
-        runner = self.config.runners.remote(self)
-        return self._run(runner, command, **kwargs)
+        return super(Connection, self).run(command, **kwargs)
 
     @opens
     def sudo(self, command, **kwargs):
@@ -575,8 +576,7 @@ class Connection(Context):
         configuration overrides in addition to the generic/global ones. Thus,
         for example, per-host sudo passwords may be configured.
         """
-        runner = self.config.runners.remote(self)
-        return self._sudo(runner, command, **kwargs)
+        return super(Connection, self).sudo(command, **kwargs)
 
     @opens
     def sftp(self):

--- a/fabric/connection.py
+++ b/fabric/connection.py
@@ -6,7 +6,7 @@ import socket
 from invoke.vendor.decorator import decorator
 from invoke.vendor.six import string_types
 
-from invoke import Context
+from invoke.context import BaseContext, Context
 from invoke.exceptions import ThreadException
 from paramiko.agent import AgentRequestHandler
 from paramiko.client import SSHClient, AutoAddPolicy
@@ -25,7 +25,7 @@ def opens(method, self, *args, **kwargs):
     return method(self, *args, **kwargs)
 
 
-class Connection(Context):
+class Connection(BaseContext):
     """
     A connection to an SSH daemon, with methods for commands and file transfer.
 

--- a/fabric/connection.py
+++ b/fabric/connection.py
@@ -222,25 +222,24 @@ class Connection(BaseContext):
         # NOTE: parent __init__ sets self._config; for now we simply overwrite
         # that below. If it's somehow problematic we would want to break parent
         # __init__ up in a manner that is more cleanly overrideable.
+        if config is None:
+            config = Config()
+        assert isinstance(config, Config)
+        # config = config.clone(into=Config)
+
+        # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+        # NOTE: the above line fixes a few tests related to config testing, but breaks
+        # breaks config sharing. See: `invokelike_multitask_invocation_preserves_config_mutation`
+
+        # TODO: when/how to run load_files, merge, load_shell_env, etc?
+        # TODO: i.e. what is the lib use case here (and honestly in invoke too)
+
         super(Connection, self).__init__(config=config)
         self._set(runner=Remote)
 
         #: A handle for a local Context that allows local commands to be ran
         #: independently of the Connection's context.
         self.local = Context(self.config.clone())
-
-        #: The .Config object referenced when handling default values (for e.g.
-        #: user or port, when not explicitly given) or deciding how to behave.
-        if config is None:
-            config = Config()
-        # Handle 'vanilla' Invoke config objects, which need cloning 'into' one
-        # of our own Configs (which grants the new defaults, etc, while not
-        # squashing them if the Invoke-level config already accounted for them)
-        elif not isinstance(config, Config):
-            config = config.clone(into=Config)
-        self._set(_config=config)
-        # TODO: when/how to run load_files, merge, load_shell_env, etc?
-        # TODO: i.e. what is the lib use case here (and honestly in invoke too)
 
         shorthand = self.derive_shorthand(host)
         host = shorthand['host']

--- a/fabric/executor.py
+++ b/fabric/executor.py
@@ -28,7 +28,7 @@ class FabExecutor(Executor):
             # 'honor that new feature of Invoke')
             # TODO: roles, other non-runtime host parameterizations, etc
             # Pre-tasks get added only once, not once per host.
-            ret.extend(self.expand_calls(call.pre, apply_hosts=False))
+            ret.extend(self.expand_calls(call.task.pre, apply_hosts=False))
             # Main task, per host
             for host in hosts:
                 ret.append(self.parameterize(call, host))
@@ -37,7 +37,7 @@ class FabExecutor(Executor):
             if not hosts:
                 ret.append(call)
             # Post-tasks added once, not once per host.
-            ret.extend(self.expand_calls(call.post, apply_hosts=False))
+            ret.extend(self.expand_calls(call.task.post, apply_hosts=False))
         # Add remainder as anonymous task
         if self.core.remainder:
             # TODO: this will need to change once there are more options for

--- a/fabric/executor.py
+++ b/fabric/executor.py
@@ -22,6 +22,8 @@ class FabExecutor(Executor):
         for call in calls:
             if isinstance(call, Task):
                 call = Call(task=call)
+            if not hasattr(call, 'host'):
+                call.host = None
             # TODO: expand this to allow multiple types of execution plans,
             # pending outcome of invoke#461 (which, if flexible enough to
             # handle intersect of dependencies+parameterization, just becomes

--- a/fabric/executor.py
+++ b/fabric/executor.py
@@ -1,12 +1,16 @@
 from invoke import Call, Executor, Task
 from invoke.util import debug
 
-from . import Connection
+from . import Config, Connection
 from .exceptions import NothingToDo
 
 
 # TODO: come up w/ a better name heh
 class FabExecutor(Executor):
+    def __init__(self, collection, config=None, core=None):
+        super(FabExecutor, self).__init__(collection, config, core)
+        self.config = self.config.clone(into=Config)
+
     def expand_calls(self, calls, apply_hosts=True):
         # Generate new call list with per-host variants & Connections inserted
         ret = []

--- a/fabric/executor.py
+++ b/fabric/executor.py
@@ -1,7 +1,7 @@
-from invoke import Call, Executor, Task
+from invoke import Call, Context, Executor
 from invoke.util import debug
 
-from . import Config, Connection
+from . import Config, Connection, LocalTask, Task
 from .exceptions import NothingToDo
 
 
@@ -60,12 +60,16 @@ class FabExecutor(Executor):
         Parameterize a Call with its Context set to a per-host Config.
         """
         debug("Parameterizing {0!r} for host {1!r}".format(call, host))
-        # Generate a custom ConnectionCall that knows how to yield a Connection
-        # in its make_context(), specifically one to the host requested here.
-        clone = call.clone(into=ConnectionCall)
+        clone = call.clone()
         # TODO: using bag-of-attrs is mildly gross but whatever, I'll take it.
         clone.host = host
         return clone
+
+    def make_context(self, call, config):
+        if isinstance(call.task, LocalTask):
+            return Context(config=config)
+        elif isinstance(call.task, Task):
+            return Connection(host=call.host, config=config)
 
     def dedupe(self, tasks):
         # Don't perform deduping, we will often have "duplicate" tasks w/
@@ -73,11 +77,3 @@ class FabExecutor(Executor):
         # TODO: might want some deduplication later on though - falls under
         # "how to mesh parameterization with pre/post/etc deduping".
         return tasks
-
-
-class ConnectionCall(Call):
-    """
-    Subclass of `invoke.tasks.Call` that generates `Connections <.Connection>`.
-    """
-    def make_context(self, config):
-        return Connection(host=self.host, config=config)

--- a/fabric/tasks.py
+++ b/fabric/tasks.py
@@ -1,0 +1,24 @@
+
+from invoke.tasks import BaseTask, Task as LocalTask, task as local_task
+from .connection import Connection
+
+__all__ = ['LocalTask', 'Task', 'local_task', 'task']
+
+
+class Task(BaseTask):
+    context_class = Connection
+
+
+def task(*args, **kwargs):
+    # @task -- no options were (probably) given.
+    if len(args) == 1 and callable(args[0]) and not isinstance(args[0], Task):
+        return Task(args[0], **kwargs)
+
+    def inner(obj):
+        # @task(pre, tasks, here)
+        if args:
+            return Task(obj, pre=args, **kwargs)
+        # @task(options)
+        else:
+            return Task(obj, **kwargs)
+    return inner

--- a/tests/_support/fabfile.py
+++ b/tests/_support/fabfile.py
@@ -1,5 +1,5 @@
-from invoke import task, Context
-from fabric import Connection
+from invoke import Context
+from fabric import local_task, task, Connection
 
 
 @task
@@ -17,7 +17,7 @@ def basic_run(c):
     c.run("nope")
 
 
-@task
+@local_task
 def expect_vanilla_Context(c):
     assert isinstance(c, Context)
     assert not isinstance(c, Connection)
@@ -64,9 +64,11 @@ def expect_identities(c):
 def first(c):
     print("First!")
 
+
 @task
 def third(c):
     print("Third!")
+
 
 @task(pre=[first], post=[third])
 def second(c, show_host=False):

--- a/tests/_support/json_conf/fabfile.py
+++ b/tests/_support/json_conf/fabfile.py
@@ -1,4 +1,4 @@
-from invoke import task
+from fabric import task
 
 
 @task

--- a/tests/_support/prompting.py
+++ b/tests/_support/prompting.py
@@ -1,4 +1,4 @@
-from invoke import task
+from fabric import task
 
 
 @task

--- a/tests/_support/py_conf/fabfile.py
+++ b/tests/_support/py_conf/fabfile.py
@@ -1,4 +1,4 @@
-from invoke import task
+from fabric import task
 
 
 @task

--- a/tests/_support/runtime_fabfile.py
+++ b/tests/_support/runtime_fabfile.py
@@ -1,4 +1,4 @@
-from invoke import task
+from fabric import task
 
 
 @task

--- a/tests/_support/yaml_conf/fabfile.py
+++ b/tests/_support/yaml_conf/fabfile.py
@@ -1,4 +1,4 @@
-from invoke import task
+from fabric import task
 
 
 @task

--- a/tests/_support/yml_conf/fabfile.py
+++ b/tests/_support/yml_conf/fabfile.py
@@ -1,4 +1,4 @@
-from invoke import task
+from fabric import task
 
 
 @task

--- a/tests/connection.py
+++ b/tests/connection.py
@@ -210,24 +210,13 @@ class Connection_:
             def can_be_specified(self):
                 c = Config(overrides={'user': 'me', 'custom': 'option'})
                 config = Connection('host', config=c).config
-                assert c is config
+                assert c == config
                 assert config['user'] == 'me'
                 assert config['custom'] == 'option'
 
-            def if_given_an_invoke_Config_we_upgrade_to_our_own_Config(self):
-                # Scenario: user has Fabric-level data present at vanilla
-                # Invoke config level, and is then creating Connection objects
-                # with those vanilla invoke Configs.
-                # (Could also _not_ have any Fabric-level data, but then that's
-                # just a base case...)
-                # TODO: adjust this if we ever switch to all our settings being
-                # namespaced...
-                vanilla = InvokeConfig(overrides={
-                    'forward_agent': True,
-                    'load_ssh_configs': False,
-                })
-                cxn = Connection('host', config=vanilla)
-                assert cxn.forward_agent is True # not False, which is default
+            @raises(AssertionError)
+            def assert_not_given_an_invoke_Config(self):
+                Connection('host', config=InvokeConfig())
 
         class gateway:
             def is_optional_and_defaults_to_None(self):

--- a/tests/connection.py
+++ b/tests/connection.py
@@ -23,9 +23,9 @@ from _util import support
 
 
 # Remote is woven in as a config default, so must be patched there
-remote_path = 'fabric.config.Remote'
+remote_path = 'fabric.connection.Remote'
 
-local_path = 'invoke.config.Local'
+local_path = 'invoke.context.Local'
 
 
 def _select_result(obj):

--- a/tests/main.py
+++ b/tests/main.py
@@ -187,7 +187,7 @@ Third!
                 assert output == expected
 
     class no_hosts_flag:
-        def calls_task_once_with_invoke_context(self):
+        def calls_local_task_once_with_invoke_context(self):
             with cd(support):
                 _run_fab("expect-vanilla-Context")
 

--- a/tests/tasks.py
+++ b/tests/tasks.py
@@ -1,0 +1,36 @@
+from pytest import raises
+
+from invoke import Context
+from fabric import task, Task, Connection
+
+
+class task_:
+    "@task"
+
+    def return_type_is_correctly_subclassed(self):
+        @task
+        def fn1(ctx):
+            pass
+
+        @task(name='foo')
+        def fn2(ctx):
+            pass
+
+        assert isinstance(fn1, Task)
+        assert isinstance(fn2, Task)
+
+
+class Task_:
+    class callability:
+        def setup(self):
+            @task
+            def mytask(ctx):
+                pass
+            self.mytask = mytask
+
+        def expects_Connection_as_first_arg(self):
+            self.mytask(Connection(host='localhost'))
+
+        def errors_if_first_arg_is_Context(self):
+            with raises(TypeError):
+                self.mytask(Context())


### PR DESCRIPTION
Hey @bitprophet. Some of these thoughts have been rattling around in my head since pycon, and I wanted to hash them out as thoroughly as possible before I forget. Mainly, I want to address the expectations of local/remote task execution [described](https://github.com/fabric/fabric/issues/1591#issuecomment-296915764) by @max-arnold and in #98, as well as the relationship of `Connection` and `Context` objects. Most of the thought work has already been done in #98, but I'm trying to distill that into a solution that is simple and non-surprising. In short,

1. There should be separate local/remote `task` definitions that always expect to operate on their respective `Context`/`Connection` objects.
2. `Connection`s should expose a separate `Context` that is explicitly used for local execution. 

----

**1:** Primarily, I want to argue that remote and local task execution should **not** be interchangeable, and by extension this should apply to `Connection` and `Context` objects. There should be separate local/remote `task` definitions that ensure that the correct context type is provided to the underlying task function.
- Interchanging Contexts/Connections with local/remote tasks seems more likely to be a user execution error than an expected outcome.
  - I would expect remote task execution to explicitly complain about the lack of a host, not to operate on the local environment and then *potentially* fail.
  - Similarly, I'd expect that local tasks should guard against remote execution. 
- More generally, fabric expects to operate on remote environments, and the context object needs to represent *execution* in remote environments. Invoke tasks should in turn expect a context that represents local execution. 
- That said, there are cases where execution is environment agnostic. Discussed in 1.1 below.

The differences in API (both current & future), kind of demonstrate that contexts and connections are not logically interchangeable.
- The `Connection.local` method is nonsensical in regards to `Context`s since they already operate on the local environment. As such, remote tasks that call `local` when operating on a `Context` will fail.
- `Connection`s will have `put`, `get`, and `reboot` operations that are similarly nonsensical for `Context`s.
- `Context`s can intermix regular python code with `run`/`sudo` calls. This behavior would be potentially incorrect on a remote `Connection`. eg, file writes would not occur on the remote server, OS info would not represent the remote server, etc...

I've started this PR as a wip demonstration for fabric, however this would also need corresponding changes to Invoke. What I'm thinking at the moment:
- Invoke should provide an abstract `BaseContext`, which all contexts inherit from.
- Invoke's `Context` should inherit `BaseContext` and more explicitly represent the local environment.
- Fabric's `Connection` should inherit `BaseContext` and more explicitly represent a remote environment.
- Alter `invoke.Task` to assert that it's first positional argument inherits `Context` (not `BaseContext`).
- Expose a `fabric.Task` that asserts its first positional argument inherits `Connection`.
- Expose a corresponding `fabric.task` decorator for `fabric.Task`s.
- Fabric should simply alias `invoke.task` as `fabric.local_task` (or something similarly appropriate).
- Should the fab executor differentiate between local and remote tasks? Maybe group them in the CLI?

**1.1:** As an extension of the above, one of the discussion points is the need to execute tasks in both local and remote environments. While this is certainly valid, how common and useful is this? Are there any non-trivial, more than just `ctx.run('whoami')` examples of this? I'd argue that this is more likely a minority of cases and it's not beneficial to cater towards it.
- Interchangeability/reusability should simply be handled with regular functions that expect any context.
- If a task truly is environment-agnostic, then it seems simple enough to either:
  - expose separate local/remote variants that wrap the same function.
  - expose a local task that can construct a Connection when appropriate.

**2:** `Connection`s are a `Context` for the sake of holding state information, but they should expose a separate `Context` for local environment execution. Change `Connection.local` to provide a *local* `Context` instead of simply aliasing the parent's `run` method. While technically backwards incompatible, the migration path should be straightforward. Altering @max-arnold's [example](https://github.com/fabric/fabric/issues/1591#issuecomment-296903582) might better illustrate this change.

```python
from fabric import task, local_task


@local_task
def build(ctx):
    with ctx.cd('/project/dir'):
        ctx.run('build > artifact.zip')


@task
def deploy(conn):
    build(conn.local)

    with conn.cd('/remote/path'), conn.local.cd('/project/dir'):
        conn.put(remote_path='build.zip', local_path='artifact.zip')
```

A few details:
- Given the API changes, both `fab -H host deploy` and `fab build` should now work as expected.
- This automatically fixes issues with `cd`/`prefix` interactions between the local and remote environment, since we're now operating on separate contexts/connections. No need for `cd` vs `lcd`.
- Easier invocation of local `sudo` commands.

**3:** Also a random, but related thought on executing `Connection('localhost').run()` as `local()`...
- Seems like a magical footgun. I'm expecting connections to operate over SSH. If I want to run local code, use `local()`. (or from the PR, `local.run()`)
- Additionally, the SSH config may contain user connection info. eg, ssh to localhost as a different user? idk.

----

Anyway, I'm definitely not married to the ideas in this PR as I've only spent a limited amount of time looking at a narrow subset of the problem. I'm sure I've missed some of the more varied/nuanced needs that have arisen over the years. 
