### PR TITLE
Add Connection.socks_proxy() and tunnels.SocksTunnelManager

### DIFF
--- a/fabric/tunnels.py
+++ b/fabric/tunnels.py
@@ -1,46 +1,60 @@
+import binascii
 import errno
+import logging
 import select
 import socket
+import struct
 import time
+import uuid
 from threading import Event
 
 from invoke.exceptions import ThreadException
 from invoke.util import ExceptionHandlingThread
+from paramiko.util import format_binary
 
 
-class TunnelManager(ExceptionHandlingThread):
+class TunnelError(Exception):
+    pass
+
+
+class SocksError(TunnelError):
+    pass
+
+
+class BaseTunnelManager(ExceptionHandlingThread):
     def __init__(self,
-        local_host, local_port,
-        remote_host, remote_port,
-        transport, finished
-    ):
-        super(TunnelManager, self).__init__()
-        self.local_address = (local_host, local_port)
-        self.remote_address = (remote_host, remote_port)
+                 local_host, local_port,
+                 transport, finished
+                 ):
+        super(BaseTunnelManager, self).__init__()
+        self.ultra_debug = False
+        self.log = logging.getLogger('fabric.tunnels')
         self.transport = transport
         self.finished = finished
+
+        # Set up OS-level listener socket on forwarded port
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        # TODO: why do we want REUSEADDR exactly? and is it portable?
+        self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        # NOTE: choosing to deal with nonblocking semantics and a fast loop,
+        # versus an older approach which blocks & expects outer scope to cause
+        # a socket exception by close()ing the socket.
+        self.sock.setblocking(0)
+        self.sock.bind((local_host, local_port))
+        self.local_address = self.sock.getsockname()
+        self.sock.listen(1)
+        self.log.debug("listening on {}".format(self.local_address))
 
     def _run(self):
         # Track each tunnel that gets opened during our lifetime
         tunnels = []
-
-        # Set up OS-level listener socket on forwarded port
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        # TODO: why do we want REUSEADDR exactly? and is it portable?
-        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        # NOTE: choosing to deal with nonblocking semantics and a fast loop,
-        # versus an older approach which blocks & expects outer scope to cause
-        # a socket exception by close()ing the socket.
-        sock.setblocking(0)
-        sock.bind(self.local_address)
-        sock.listen(1)
 
         while not self.finished.is_set():
             # Main loop-wait: accept connections on the local listener
             # NOTE: EAGAIN means "you're nonblocking and nobody happened to
             # connect at this point in time"
             try:
-                tun_sock, local_addr = sock.accept()
+                tun_sock, local_addr = self.sock.accept()
                 # Set TCP_NODELAY to match OpenSSH's forwarding socket behavior
                 tun_sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
             except socket.error as e:
@@ -50,21 +64,24 @@ class TunnelManager(ExceptionHandlingThread):
                     continue
                 raise
 
-            # Set up direct-tcpip channel on server end
-            # TODO: refactor w/ what's used for gateways
-            channel = self.transport.open_channel(
-                'direct-tcpip',
-                self.remote_address,
-                local_addr,
-            )
+            channel = None
+            try:
+                channel = self._handle_accept(tun_sock, local_addr)
+            except TunnelError:
+                self.log.debug("tunnel exception.", exc_info=True)
 
-            # Set up 'worker' thread for this specific connection to our
-            # tunnel, plus its dedicated signal event (which will appear as a
-            # public attr, no need to track both independently).
-            finished = Event()
-            tunnel = Tunnel(channel=channel, sock=tun_sock, finished=finished)
-            tunnel.start()
-            tunnels.append(tunnel)
+            if not channel:
+                tun_sock.close()
+            else:
+                # Set up 'worker' thread for this specific connection to our
+                # tunnel, plus its dedicated signal event (which will appear as
+                # public attr, no need to track both independently).
+                finished = Event()
+                tunnel = Tunnel(channel=channel,
+                                sock=tun_sock,
+                                finished=finished)
+                tunnel.start()
+                tunnels.append(tunnel)
 
         exceptions = []
         # Propogate shutdown signal to all tunnels & wait for closure
@@ -83,7 +100,266 @@ class TunnelManager(ExceptionHandlingThread):
 
         # All we have left to close is our own sock.
         # TODO: use try/finally?
-        sock.close()
+        self.sock.close()
+
+    def _open_channel(self, remote_addr, local_addr):
+        # Set up direct-tcpip channel on server end
+        # TODO: refactor w/ what's used for gateways
+        self.log.debug("establishing channel to {}:{}".format(*remote_addr))
+        return self.transport.open_channel(
+            'direct-tcpip',
+            remote_addr,
+            local_addr,
+        )
+
+    def _handle_accept(self, sock, addr):
+        raise NotImplementedError()
+
+    def _send_all(self, sock, out):
+        if self.ultra_debug:
+            for l in format_binary(out, 'OUT: '):
+                self.log.debug(l)
+        while len(out) > 0:
+            n = sock.send(out)
+            if n <= 0:
+                raise EOFError()
+            if n == len(out):
+                return
+            out = out[n:]
+        return
+
+    def _send_struct(self, sock, fmt, *args):
+        self._send_all(sock, struct.pack(fmt, *args))
+
+    def _read_all(self, sock, n):
+        out = bytes()
+        while n > 0:
+            while True:
+                read, write, err = select.select([sock], [], [], 0.1)
+                if len(read) > 0:
+                    x = sock.recv(n)
+                    break
+
+            if len(x) == 0:
+                raise EOFError()
+            out += x
+            n -= len(x)
+        if self.ultra_debug:
+            for l in format_binary(out, 'IN: '):
+                self.log.debug(l)
+        return out
+
+    def _read_struct(self, sock, fmt):
+        n = struct.calcsize(fmt)
+        data = self._read_all(sock, n)
+        return struct.unpack(fmt, data)
+
+
+class TunnelManager(BaseTunnelManager):
+    def __init__(self,
+                 local_host, local_port,
+                 remote_host, remote_port,
+                 transport, finished
+                 ):
+        super(TunnelManager, self).__init__(local_host, local_port,
+                                            transport, finished)
+        self.remote_address = (remote_host, remote_port)
+
+    def _handle_accept(self, sock, addr):
+        """Create and return a channel to the remote_address."""
+        try:
+            return self._open_channel(self.remote_address, addr)
+        except Exception as e:
+            raise TunnelError("exception ({}) while opening channel".format(e))
+
+
+SOCKS4_VERSION = 4
+SOCKS5_VERSION = 5
+RESERVED = 0
+
+AUTH_VERSION = 1
+AUTH_NONE, AUTH_GSSAPI, AUTH_USERNAME_PASSWORD = range(3)
+AUTH_NO_ACCEPTABLE_METHODS = 0xFF
+
+COMMAND_CONNECT, COMMAND_BIND, COMMAND_UDP_ASSOCIATE = range(1, 4)
+
+ATYP_IPV4, _, ATYP_DOMAINNAME, ATYP_IPV6 = range(1, 5)
+
+REPLY_SUCCEEDED, REPLY_GENERAL_FAILURE, REPLY_NOT_ALLOWED, \
+    REPLY_NETWORK_UNREACHABLE, REPLY_HOST_UNREACHABLE, \
+    REPLY_CONNECTION_REFUSED, REPLY_TTL_EXPIRED, REPLY_COMMAND_NOT_SUPPORTED, \
+    REPLY_ATYP_NOT_SUPPORTED = range(9)
+
+REPLY_REQUEST_GRANTED, REPLY_REJECTED_OR_FAILED = range(90, 92)
+
+
+class SocksTunnelManager(BaseTunnelManager):
+    """A Socks 4/5 proxy that channels connections through a transport.
+
+    Supports the CONNECT command with or without username/password
+    authentication. Does not support the BIND or UDP ASSOCIATE commands.
+
+    .. versionadded:: 2.0
+    """
+
+    def __init__(self,
+                 local_host, local_port,
+                 transport, finished,
+                 authenticate=None,
+                 ):
+        super(SocksTunnelManager, self).__init__(local_host, local_port,
+                                                 transport, finished)
+        if authenticate and isinstance(authenticate, tuple):
+            self.authenticate = authenticate
+        elif authenticate:
+            self.authenticate = (str(uuid.uuid4()), str(uuid.uuid4()))
+        else:
+            self.authenticate = None
+
+        self.proxy_uri = "socks5://{}{}:{}".format(
+            "{}:{}@".format(*self.authenticate) if authenticate else '',
+            *self.local_address)
+
+    def _handle_accept(self, sock, addr):
+        """Dialog with client to authenticate and create remote channel."""
+        # Reference: SOCKS5 https://tools.ietf.org/html/rfc1928
+        #            SOCSK4 https://www.openssh.com/txt/socks4.protocol
+        v, = self._read_struct(sock, '!B')
+
+        if v == SOCKS4_VERSION:
+            if not self.authenticate:
+                return self._handle_socks4(sock, addr)
+            else:
+                msg = 'socks4 protocol unsupported with authentication'
+                raise SocksError(msg)
+        elif v == SOCKS5_VERSION:
+            return self._handle_socks5(sock, addr)
+        else:
+            raise SocksError("unsupported socks version {}".format(v))
+
+    def _handle_socks4(self, sock, addr):
+        command, = self._read_struct(sock, '!B')
+        if command != COMMAND_CONNECT:
+            raise SocksError("unsupported socks command {}".format(command))
+
+        dst_port, = self._read_struct(sock, '!H')
+        dst_bytes = self._read_struct(sock, '!BBBB')
+        dst = '.'.join(str(x) for x in dst_bytes)
+
+        while self._read_struct(sock, '!B')[0] != 0:
+            # consume the userid, which is null terminated.
+            pass
+
+        response_code = REPLY_REQUEST_GRANTED
+        try:
+            return self._open_channel((dst, dst_port), addr)
+        except Exception as e:
+            response_code = REPLY_REJECTED_OR_FAILED
+            raise SocksError("exception ({}) while opening channel".format(e))
+        finally:
+            self._send_struct(sock, '!BBHBBBB',
+                              0, response_code, dst_port, *dst_bytes)
+
+    def _handle_socks5(self, sock, addr):
+        self._handle_auth(sock)
+
+        v, command, _ = self._read_struct(sock, '!BBB')
+        if v != SOCKS5_VERSION:
+            raise SocksError("unsupported socks version {}".format(v))
+
+        if command == COMMAND_CONNECT:
+            return self._handle_connect(sock, addr)
+        else:
+            self._send_struct(sock, '!BBB',
+                              SOCKS5_VERSION, REPLY_COMMAND_NOT_SUPPORTED,
+                              RESERVED)
+            raise SocksError("unsupported socks command {}".format(command))
+
+    def _handle_connect(self, sock, addr):
+        dst, addr_data = self._handle_atyp(sock)
+        dst_port, = self._read_struct(sock, '!H')
+
+        response_code = REPLY_SUCCEEDED
+        try:
+            return self._open_channel((dst, dst_port), addr)
+        except Exception as e:
+            response_code = REPLY_GENERAL_FAILURE
+            raise SocksError("exception ({}) while opening channel".format(e))
+        finally:
+            self._send_struct(sock, '!BBB',
+                              SOCKS5_VERSION, response_code, RESERVED)
+            self._send_all(sock, addr_data)
+            self._send_struct(sock, '!H', dst_port)
+
+    def _handle_atyp(self, sock):
+        atyp, = self._read_struct(sock, '!B')
+        if atyp == ATYP_IPV4:
+            addr_data = self._read_all(sock, 4)
+            dst = '.'.join(str(x) for x in struct.unpack('!4B', addr_data))
+        elif atyp == ATYP_IPV6:
+            addr_data = self._read_all(sock, 16)
+            dst = struct.unpack('!8H', addr_data)
+            dst = ':'.join(binascii.hexlify(x) for x in dst)
+        elif atyp == ATYP_DOMAINNAME:
+            dst_len, = self._read_struct(sock, '!B')
+            dst, = self._read_struct(sock, "!{}s".format(dst_len))
+            addr_data = struct.pack("!B{}s".format(dst_len), dst_len, dst)
+        else:
+            self._send_struct(sock, '!BBB',
+                              SOCKS5_VERSION, REPLY_ATYP_NOT_SUPPORTED,
+                              RESERVED)
+            raise SocksError("unsupported socks address type {}".format(atyp))
+        return dst, struct.pack('!B', atyp) + addr_data
+
+    def _handle_auth(self, sock):
+        """Handle authentication of a socks request.
+
+        :param sock: The socket with the client
+        :return: True if the request is authenticated, False otherwise
+        """
+
+        # Reference: https://tools.ietf.org/html/rfc1929
+        auth_methods_length, = self._read_struct(sock, '!B')
+        methods = self._read_struct(
+            sock, "!{}B".format(auth_methods_length)
+        )
+
+        if not self.authenticate and AUTH_NONE in methods:
+            self._send_struct(sock, '!BB', SOCKS5_VERSION, AUTH_NONE)
+            return
+
+        # Require username/password authentication.
+        if AUTH_USERNAME_PASSWORD not in methods:
+            self._send_struct(sock, '!B', AUTH_NO_ACCEPTABLE_METHODS)
+            raise SocksError('rejecting socks auth as client does not accept'
+                             ' user/pass.')
+
+        self._send_struct(sock, '!BB', SOCKS5_VERSION, AUTH_USERNAME_PASSWORD)
+
+        # Read and parse username/password data
+        v, username_length = self._read_struct(sock, '!BB')
+        if v != AUTH_VERSION:
+            raise SocksError('bad socks auth version from client')
+
+        username, password_length = self._read_struct(sock,
+                                                      "!{}sB".format(
+                                                          username_length))
+
+        password, = self._read_struct(sock,
+                                      "{}s".format(password_length))
+
+        if (username.decode(), password.decode()) != self.authenticate:
+            self._send_struct(sock, '!BB',
+                              AUTH_VERSION, REPLY_GENERAL_FAILURE)
+            raise SocksError('socks username/password mismatch')
+
+        self._send_struct(sock, '!BB', AUTH_VERSION, REPLY_SUCCEEDED)
+        self.log.debug('socks auth succeeded')
+
+    def _wait(self, sock):
+        """Wait for data to be ready to read."""
+        select.select([sock], [], [])
+        return sock
 
 
 class Tunnel(ExceptionHandlingThread):
@@ -92,6 +368,7 @@ class Tunnel(ExceptionHandlingThread):
 
     .. versionadded:: 2.0
     """
+
     def __init__(self, channel, sock, finished):
         self.channel = channel
         self.sock = sock

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,10 @@ invocations>=0.17,<2.0
 # pytest-relaxed for test organization, display etc tweaks
 pytest-relaxed==1.0.0
 pytest==3.1.2
+# for testing TunnelManagers
+requests==2.18.4
+PySocks==1.6.8
+pytest-localserver==0.4.1
 # pytest-cov for coverage
 pytest-cov==2.5.1
 six==1.10.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,3 +92,12 @@ def client():
         client = SSHClient.return_value
         client.get_transport.return_value = Mock(active=True)
         yield client
+
+@fixture(scope='session')
+def ok_httpserver(request):
+    from pytest_localserver import http
+    server = http.ContentServer()
+    server.start()
+    request.addfinalizer(server.stop)
+    server.serve_content('ok', 200)
+    return server

--- a/tests/tunnels.py
+++ b/tests/tunnels.py
@@ -1,0 +1,259 @@
+import socket
+import struct
+import threading
+
+import requests
+from mock import patch, Mock, call, ANY
+from pytest import raises
+
+from fabric.tunnels import BaseTunnelManager, TunnelManager, SocksTunnelManager
+
+
+def _local_channel(remote_addr, local_addr):
+    return socket.create_connection(remote_addr)
+
+
+class BaseTunnelManager_:
+
+    @patch('socket.socket')
+    def setup(self, socket):
+        self.sock = socket.return_value
+        self.transport = Mock()
+        self.finished = Mock()
+        self.mgr = BaseTunnelManager('localhost',
+                                     5555,
+                                     self.transport,
+                                     self.finished)
+
+        # Turn on ultra_debug for code coverage
+        self.mgr.ultra_debug = True
+
+    class init:
+        "__init__"
+
+        def listens_on_port(self):
+            self.sock.bind.assert_called_once_with(('localhost', 5555))
+            self.sock.listen.assert_called()
+
+    class reads_and_writes:
+        @patch('select.select')
+        def read_all_reads_all(self, select):
+            sock = Mock()
+            select.return_value = ([sock], [], [])
+            sock.recv.return_value = bytes(10)
+
+            data = self.mgr._read_all(sock, 100)
+
+            assert len(data) == 100
+            assert sock.recv.call_count == 10
+
+        @patch('select.select')
+        def read_all_raises_eof(self, select):
+            sock = Mock()
+            select.return_value = ([sock], [], [])
+            sock.recv.return_value = bytes()
+
+            with raises(EOFError):
+                self.mgr._read_all(sock, 1)
+
+        @patch.object(BaseTunnelManager, '_read_all')
+        def read_struct(self, read_all):
+            read_all.return_value = struct.pack('H10s', 42, b'HelloWorld')
+            (n, s) = self.mgr._read_struct(Mock(), 'H10s')
+            assert n == 42
+            assert s == b'HelloWorld'
+            read_all.assert_called_with(ANY, 12)
+
+        def send_all_sends_all(self):
+            data = struct.pack('100B', *range(100))
+            sock = Mock()
+            sock.send.return_value = 10
+
+            self.mgr._send_all(sock, data)
+            calls = [call(data[n:]) for n in range(0, 100, 10)]
+            sock.send.assert_has_calls(calls)
+
+        def send_all_raises_eof(self):
+            sock = Mock()
+            sock.send.return_value = 0
+            with raises(EOFError):
+                self.mgr._send_all(sock, b'data')
+
+        @patch.object(BaseTunnelManager, '_send_all')
+        def send_struct(self, send_all):
+            self.mgr._send_struct(Mock(), 'H10s', 42, b'HelloWorld')
+            d = struct.pack('H10s', 42, b'HelloWorld')
+            send_all.assert_called_with(ANY, d)
+
+        def handle_accept_not_implemented(self):
+            self.finished.is_set.side_effect = iter([False, True])
+            tun_sock = Mock()
+            self.sock.accept.return_value = (tun_sock, 0)
+            with raises(NotImplementedError):
+                self.mgr._run()
+
+        @patch.object(BaseTunnelManager, '_handle_accept', return_value=None)
+        def handle_accept_called(self, handle_accept):
+            self.finished.is_set.side_effect = iter([False, True])
+            tun_sock = Mock()
+            self.sock.accept.return_value = (tun_sock, 0)
+            self.mgr._run()
+            handle_accept.assert_called_with(tun_sock, 0)
+
+        def open_channel_opens_direct_tcpip_channel(self):
+            r = ('remotehost', 8888)
+            l = ('localhost', 5555)
+            self.mgr._open_channel(r, l)
+            self.transport.assert_call_with('direct-tcpip', r, l)
+
+
+class TunnelManager_:
+    @patch('socket.socket')
+    def setup(self, socket):
+        self.sock = socket.return_value
+        self.transport = Mock()
+        self.finished = Mock()
+        self.mgr = TunnelManager('localhost',
+                                 5555,
+                                 'remotehost',
+                                 8888,
+                                 self.transport,
+                                 self.finished)
+
+        # Turn on ultra_debug for code coverage
+        self.mgr.ultra_debug = True
+
+    @patch.object(BaseTunnelManager, '_open_channel')
+    def handle_accept_opens_channel(self, open_channel):
+        self.finished.is_set.side_effect = iter([False, True])
+        tun_sock = Mock()
+        self.sock.accept.return_value = (tun_sock, 0)
+        open_channel.return_value = None
+
+        self.mgr._run()
+        open_channel.assert_called_with(('remotehost', 8888), 0)
+
+    @patch.object(BaseTunnelManager, '_open_channel',
+                  side_effect=_local_channel)
+    def tunnels_ok(self, open_channel, ok_httpserver):
+        self.finished.is_set.side_effect = iter([False, True])
+        tun_sock = Mock()
+        self.sock.accept.return_value = (tun_sock, 0)
+        open_channel.return_value = None
+
+        self.mgr._run()
+        open_channel.assert_called_with(('remotehost', 8888), 0)
+
+
+class SocksTunnelManager_:
+    class init:
+        "__init__"
+
+        @patch('socket.socket')
+        @patch('uuid.uuid4')
+        def random_auth_is_generated(self, uuid4, socket):
+            socket.return_value.getsockname.return_value = ('localhost', 1080)
+            uuid4.side_effect = iter(['random1', 'random2'])
+            mgr = SocksTunnelManager('localhost', 0, None, None,
+                                     authenticate=1)
+            assert uuid4.call_count == 2
+            assert mgr.authenticate == ('random1', 'random2')
+
+        @patch('socket.socket')
+        def given_auth_is_used(self, socket):
+            socket.return_value.getsockname.return_value = ('localhost', 1080)
+            mgr = SocksTunnelManager('localhost', 0, None, None,
+                                     authenticate=('user', 'pass'))
+            assert mgr.authenticate == ('user', 'pass')
+
+    class socks4:
+
+        @patch.object(BaseTunnelManager, '_open_channel',
+                      side_effect=_local_channel)
+        def http_get(self, open_channel, ok_httpserver):
+            """Test end-to-end flow. Transport is the only thing mocked."""
+            # sanity test our ok_httpserver fixture
+            r = requests.get(ok_httpserver.url)
+            r.raise_for_status()
+            assert r.text == 'ok'
+
+            # start the socks proxy
+            mgr = SocksTunnelManager('localhost', 0, Mock(), threading.Event())
+            mgr.ultra_debug = True
+            mgr.start()
+
+            # use it
+            proxy = {'http': mgr.proxy_uri.replace('socks5', 'socks4')}
+            r = requests.get(ok_httpserver.url, proxies=proxy)
+            r.raise_for_status()
+            assert r.text == 'ok'
+
+            # stop the proxy
+            mgr.finished.set()
+            mgr.join()
+
+            # ensure this now fails with the proxy stopped
+            with raises(requests.exceptions.ConnectionError):
+                requests.get(ok_httpserver.url, proxies=proxy)
+
+    class socks5:
+
+        @patch.object(BaseTunnelManager, '_open_channel',
+                      side_effect=_local_channel)
+        def http_get(self, open_channel, ok_httpserver):
+            """Test end-to-end flow. Transport is the only thing mocked."""
+            # sanity test our ok_httpserver fixture
+            r = requests.get(ok_httpserver.url)
+            r.raise_for_status()
+            assert r.text == 'ok'
+
+            # start the socks proxy
+            mgr = SocksTunnelManager('localhost', 0, Mock(),
+                                     threading.Event(),
+                                     authenticate=False)
+            mgr.ultra_debug = True
+            mgr.start()
+
+            # use it
+            proxy = {'http': mgr.proxy_uri}
+            r = requests.get(ok_httpserver.url, proxies=proxy)
+            r.raise_for_status()
+            assert r.text == 'ok'
+
+            # stop the proxy
+            mgr.finished.set()
+            mgr.join()
+
+            # ensure this now fails with the proxy stopped
+            with raises(requests.exceptions.ConnectionError):
+                requests.get(ok_httpserver.url, proxies=proxy)
+
+        @patch.object(BaseTunnelManager, '_open_channel',
+                      side_effect=_local_channel)
+        def http_get_with_authentication(self, open_channel, ok_httpserver):
+            """Test end-to-end flow. Transport is the only thing mocked."""
+            # sanity test our ok_httpserver fixture
+            r = requests.get(ok_httpserver.url)
+            r.raise_for_status()
+            assert r.text == 'ok'
+
+            # start the socks proxy
+            mgr = SocksTunnelManager('localhost', 0, Mock(),
+                                     threading.Event(),
+                                     authenticate=True)
+            mgr.ultra_debug = True
+            mgr.start()
+
+            # use it
+            proxy = {'http': mgr.proxy_uri}
+            r = requests.get(ok_httpserver.url, proxies=proxy)
+            r.raise_for_status()
+            assert r.text == 'ok'
+
+            # stop the proxy
+            mgr.finished.set()
+            mgr.join()
+
+            # ensure this now fails with the proxy stopped
+            with raises(requests.exceptions.ConnectionError):
+                requests.get(ok_httpserver.url, proxies=proxy)


### PR DESCRIPTION
Opening this PR against the v2 branch because it seems like that is where active development is. Really love the changes you've made in v2!

This PR adds a socks5 compliant proxy tunnel manager and an associated contextmanager at Connection.socks_proxy().

Hoping to get your early feedback on this PR.