### PR TITLE
Fix link to contribution-guide.org

### DIFF
--- a/sites/www/development.rst
+++ b/sites/www/development.rst
@@ -25,7 +25,7 @@ There are a number of ways to get involved with Fabric:
   `ticket tracker`_ first, though,
   when submitting feature ideas.)
 * **Report bugs or submit feature requests.** We follow `contribution-guide.org
-  <http://contribution.org>`_'s guidelines, so please check them out before
+  <http://contribution-guide.org>`_'s guidelines, so please check them out before
   visiting the `ticket tracker`_.
 
 .. _ticket tracker: https://github.com/fabric/fabric/issues


### PR DESCRIPTION
Note: this is an ad-hoc PR, done entirely via the GitHub interface (i.e., no local checkout).