### PR TITLE
[wip] Separating local and remote execution contexts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
   # TODO: real test matrix with at least some cells combining different invoke
   # and/or paramiko versions, released versions, etc
   # Invoke from master for parity
-  - "pip install -e git+https://github.com/pyinvoke/invoke#egg=invoke"
+  - "pip install -e git+https://github.com/rpkilby/invoke@context-runner#egg=invoke"
   # And invocations, ditto
   - "pip install -e git+https://github.com/pyinvoke/invocations#egg=invocations"
   # Paramiko ditto

--- a/fabric/__init__.py
+++ b/fabric/__init__.py
@@ -2,4 +2,5 @@
 from ._version import __version_info__, __version__
 from .connection import Config, Connection
 from .runners import Remote, Result
+from .tasks import local_task, task, LocalTask, Task
 from .group import Group, SerialGroup, ThreadingGroup, GroupResult

--- a/fabric/config.py
+++ b/fabric/config.py
@@ -5,7 +5,6 @@ import os
 from invoke.config import Config as InvokeConfig, merge_dicts
 from paramiko.config import SSHConfig
 
-from .runners import Remote
 from .util import get_local_user, debug
 
 
@@ -244,9 +243,6 @@ class Config(InvokeConfig):
             'port': 22,
             'run': {
                 'replace_env': True,
-            },
-            'runners': {
-                'remote': Remote,
             },
             'ssh_config_path': None,
             'tasks': {

--- a/fabric/connection.py
+++ b/fabric/connection.py
@@ -103,6 +103,7 @@ class Connection(Context):
     connect_kwargs = None
     client = None
     transport = None
+    local = None
     _sftp = None
     _agent_handler = None
 
@@ -223,6 +224,10 @@ class Connection(Context):
         # that below. If it's somehow problematic we would want to break parent
         # __init__ up in a manner that is more cleanly overrideable.
         super(Connection, self).__init__(config=config)
+
+        #: A handle for a local Context that allows local commands to be ran
+        #: independently of the Connection's context.
+        self.local = Context(self.config.clone())
 
         #: The .Config object referenced when handling default values (for e.g.
         #: user or port, when not explicitly given) or deciding how to behave.
@@ -586,19 +591,6 @@ class Connection(Context):
         """
         runner = self.config.runners.remote(self)
         return self._sudo(runner, command, **kwargs)
-
-    def local(self, *args, **kwargs):
-        """
-        Execute a shell command on the local system.
-
-        This method is effectively a wrapper of `invoke.run`; see its docs for
-        details and call signature.
-
-        .. versionadded:: 2.0
-        """
-        # Superclass run() uses runners.local, so we can literally just call it
-        # straight.
-        return super(Connection, self).run(*args, **kwargs)
 
     @opens
     def sftp(self):

--- a/fabric/connection.py
+++ b/fabric/connection.py
@@ -14,6 +14,7 @@ from paramiko.config import SSHConfig
 from paramiko.proxy import ProxyCommand
 
 from .config import Config
+from .runners import Remote
 from .transfer import Transfer
 from .tunnels import TunnelManager, Tunnel
 
@@ -224,6 +225,7 @@ class Connection(Context):
         # that below. If it's somehow problematic we would want to break parent
         # __init__ up in a manner that is more cleanly overrideable.
         super(Connection, self).__init__(config=config)
+        self._set(runner=Remote)
 
         #: A handle for a local Context that allows local commands to be ran
         #: independently of the Connection's context.
@@ -574,8 +576,7 @@ class Connection(Context):
 
         .. versionadded:: 2.0
         """
-        runner = self.config.runners.remote(self)
-        return self._run(runner, command, **kwargs)
+        return super(Connection, self).run(command, **kwargs)
 
     @opens
     def sudo(self, command, **kwargs):
@@ -589,8 +590,7 @@ class Connection(Context):
 
         .. versionadded:: 2.0
         """
-        runner = self.config.runners.remote(self)
-        return self._sudo(runner, command, **kwargs)
+        return super(Connection, self).sudo(command, **kwargs)
 
     @opens
     def sftp(self):

--- a/fabric/connection.py
+++ b/fabric/connection.py
@@ -412,6 +412,9 @@ class Connection(BaseContext):
         return hash(self._identity())
 
     def derive_shorthand(self, host_string):
+        if host_string is None:
+            return {'user': '', 'host': '', 'port': ''}
+
         user_hostport = host_string.rsplit('@', 1)
         hostport = user_hostport.pop()
         user = user_hostport[0] if user_hostport and user_hostport[0] else None

--- a/fabric/connection.py
+++ b/fabric/connection.py
@@ -224,25 +224,24 @@ class Connection(BaseContext):
         # NOTE: parent __init__ sets self._config; for now we simply overwrite
         # that below. If it's somehow problematic we would want to break parent
         # __init__ up in a manner that is more cleanly overrideable.
+        if config is None:
+            config = Config()
+        assert isinstance(config, Config)
+        # config = config.clone(into=Config)
+
+        # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+        # NOTE: the above line fixes a few tests related to config testing, but breaks
+        # breaks config sharing. See: `invokelike_multitask_invocation_preserves_config_mutation`
+
+        # TODO: when/how to run load_files, merge, load_shell_env, etc?
+        # TODO: i.e. what is the lib use case here (and honestly in invoke too)
+
         super(Connection, self).__init__(config=config)
         self._set(runner=Remote)
 
         #: A handle for a local Context that allows local commands to be ran
         #: independently of the Connection's context.
         self.local = Context(self.config.clone())
-
-        #: The .Config object referenced when handling default values (for e.g.
-        #: user or port, when not explicitly given) or deciding how to behave.
-        if config is None:
-            config = Config()
-        # Handle 'vanilla' Invoke config objects, which need cloning 'into' one
-        # of our own Configs (which grants the new defaults, etc, while not
-        # squashing them if the Invoke-level config already accounted for them)
-        elif not isinstance(config, Config):
-            config = config.clone(into=Config)
-        self._set(_config=config)
-        # TODO: when/how to run load_files, merge, load_shell_env, etc?
-        # TODO: i.e. what is the lib use case here (and honestly in invoke too)
 
         shorthand = self.derive_shorthand(host)
         host = shorthand['host']

--- a/fabric/connection.py
+++ b/fabric/connection.py
@@ -6,7 +6,7 @@ import socket
 from invoke.vendor.decorator import decorator
 from invoke.vendor.six import string_types
 
-from invoke import Context
+from invoke.context import BaseContext, Context
 from invoke.exceptions import ThreadException
 from paramiko.agent import AgentRequestHandler
 from paramiko.client import SSHClient, AutoAddPolicy
@@ -25,7 +25,7 @@ def opens(method, self, *args, **kwargs):
     return method(self, *args, **kwargs)
 
 
-class Connection(Context):
+class Connection(BaseContext):
     """
     A connection to an SSH daemon, with methods for commands and file transfer.
 

--- a/fabric/executor.py
+++ b/fabric/executor.py
@@ -28,7 +28,7 @@ class FabExecutor(Executor):
             # 'honor that new feature of Invoke')
             # TODO: roles, other non-runtime host parameterizations, etc
             # Pre-tasks get added only once, not once per host.
-            ret.extend(self.expand_calls(call.pre, apply_hosts=False))
+            ret.extend(self.expand_calls(call.task.pre, apply_hosts=False))
             # Main task, per host
             for host in hosts:
                 ret.append(self.parameterize(call, host))
@@ -37,7 +37,7 @@ class FabExecutor(Executor):
             if not hosts:
                 ret.append(call)
             # Post-tasks added once, not once per host.
-            ret.extend(self.expand_calls(call.post, apply_hosts=False))
+            ret.extend(self.expand_calls(call.task.post, apply_hosts=False))
         # Add remainder as anonymous task
         if self.core.remainder:
             # TODO: this will need to change once there are more options for

--- a/fabric/executor.py
+++ b/fabric/executor.py
@@ -22,6 +22,8 @@ class FabExecutor(Executor):
         for call in calls:
             if isinstance(call, Task):
                 call = Call(task=call)
+            if not hasattr(call, 'host'):
+                call.host = None
             # TODO: expand this to allow multiple types of execution plans,
             # pending outcome of invoke#461 (which, if flexible enough to
             # handle intersect of dependencies+parameterization, just becomes

--- a/fabric/executor.py
+++ b/fabric/executor.py
@@ -1,12 +1,16 @@
 from invoke import Call, Executor, Task
 from invoke.util import debug
 
-from . import Connection
+from . import Config, Connection
 from .exceptions import NothingToDo
 
 
 # TODO: come up w/ a better name heh
 class FabExecutor(Executor):
+    def __init__(self, collection, config=None, core=None):
+        super(FabExecutor, self).__init__(collection, config, core)
+        self.config = self.config.clone(into=Config)
+
     def expand_calls(self, calls, apply_hosts=True):
         # Generate new call list with per-host variants & Connections inserted
         ret = []

--- a/fabric/tasks.py
+++ b/fabric/tasks.py
@@ -1,0 +1,24 @@
+
+from invoke.tasks import BaseTask, Task as LocalTask, task as local_task
+from .connection import Connection
+
+__all__ = ['LocalTask', 'Task', 'local_task', 'task']
+
+
+class Task(BaseTask):
+    context_class = Connection
+
+
+def task(*args, **kwargs):
+    # @task -- no options were (probably) given.
+    if len(args) == 1 and callable(args[0]) and not isinstance(args[0], Task):
+        return Task(args[0], **kwargs)
+
+    def inner(obj):
+        # @task(pre, tasks, here)
+        if args:
+            return Task(obj, pre=args, **kwargs)
+        # @task(options)
+        else:
+            return Task(obj, **kwargs)
+    return inner

--- a/tests/_support/fabfile.py
+++ b/tests/_support/fabfile.py
@@ -1,5 +1,5 @@
-from invoke import task, Context
-from fabric import Connection
+from invoke import Context
+from fabric import local_task, task, Connection
 
 
 @task
@@ -17,7 +17,7 @@ def basic_run(c):
     c.run("nope")
 
 
-@task
+@local_task
 def expect_vanilla_Context(c):
     assert isinstance(c, Context)
     assert not isinstance(c, Connection)
@@ -64,9 +64,11 @@ def expect_identities(c):
 def first(c):
     print("First!")
 
+
 @task
 def third(c):
     print("Third!")
+
 
 @task(pre=[first], post=[third])
 def second(c, show_host=False):

--- a/tests/_support/json_conf/fabfile.py
+++ b/tests/_support/json_conf/fabfile.py
@@ -1,4 +1,4 @@
-from invoke import task
+from fabric import task
 
 
 @task

--- a/tests/_support/prompting.py
+++ b/tests/_support/prompting.py
@@ -1,4 +1,4 @@
-from invoke import task
+from fabric import task
 
 
 @task

--- a/tests/_support/py_conf/fabfile.py
+++ b/tests/_support/py_conf/fabfile.py
@@ -1,4 +1,4 @@
-from invoke import task
+from fabric import task
 
 
 @task

--- a/tests/_support/runtime_fabfile.py
+++ b/tests/_support/runtime_fabfile.py
@@ -1,4 +1,4 @@
-from invoke import task
+from fabric import task
 
 
 @task

--- a/tests/_support/yaml_conf/fabfile.py
+++ b/tests/_support/yaml_conf/fabfile.py
@@ -1,4 +1,4 @@
-from invoke import task
+from fabric import task
 
 
 @task

--- a/tests/_support/yml_conf/fabfile.py
+++ b/tests/_support/yml_conf/fabfile.py
@@ -1,4 +1,4 @@
-from invoke import task
+from fabric import task
 
 
 @task

--- a/tests/connection.py
+++ b/tests/connection.py
@@ -210,24 +210,13 @@ class Connection_:
             def can_be_specified(self):
                 c = Config(overrides={'user': 'me', 'custom': 'option'})
                 config = Connection('host', config=c).config
-                assert c is config
+                assert c == config
                 assert config['user'] == 'me'
                 assert config['custom'] == 'option'
 
-            def if_given_an_invoke_Config_we_upgrade_to_our_own_Config(self):
-                # Scenario: user has Fabric-level data present at vanilla
-                # Invoke config level, and is then creating Connection objects
-                # with those vanilla invoke Configs.
-                # (Could also _not_ have any Fabric-level data, but then that's
-                # just a base case...)
-                # TODO: adjust this if we ever switch to all our settings being
-                # namespaced...
-                vanilla = InvokeConfig(overrides={
-                    'forward_agent': True,
-                    'load_ssh_configs': False,
-                })
-                cxn = Connection('host', config=vanilla)
-                assert cxn.forward_agent is True # not False, which is default
+            @raises(AssertionError)
+            def assert_not_given_an_invoke_Config(self):
+                Connection('host', config=InvokeConfig())
 
         class gateway:
             def is_optional_and_defaults_to_None(self):

--- a/tests/connection.py
+++ b/tests/connection.py
@@ -23,9 +23,9 @@ from _util import support
 
 
 # Remote is woven in as a config default, so must be patched there
-remote_path = 'fabric.config.Remote'
+remote_path = 'fabric.connection.Remote'
 
-local_path = 'invoke.config.Local'
+local_path = 'invoke.context.Local'
 
 
 def _select_result(obj):

--- a/tests/main.py
+++ b/tests/main.py
@@ -187,7 +187,7 @@ Third!
                 assert output == expected
 
     class no_hosts_flag:
-        def calls_task_once_with_invoke_context(self):
+        def calls_local_task_once_with_invoke_context(self):
             with cd(support):
                 _run_fab("expect-vanilla-Context")
 

--- a/tests/tasks.py
+++ b/tests/tasks.py
@@ -1,0 +1,36 @@
+from pytest import raises
+
+from invoke import Context
+from fabric import task, Task, Connection
+
+
+class task_:
+    "@task"
+
+    def return_type_is_correctly_subclassed(self):
+        @task
+        def fn1(ctx):
+            pass
+
+        @task(name='foo')
+        def fn2(ctx):
+            pass
+
+        assert isinstance(fn1, Task)
+        assert isinstance(fn2, Task)
+
+
+class Task_:
+    class callability:
+        def setup(self):
+            @task
+            def mytask(ctx):
+                pass
+            self.mytask = mytask
+
+        def expects_Connection_as_first_arg(self):
+            self.mytask(Connection(host='localhost'))
+
+        def errors_if_first_arg_is_Context(self):
+            with raises(TypeError):
+                self.mytask(Context())


### PR DESCRIPTION
This is a rebase of #1637 relative to the updated master branch. There is a lot of discussion/context in the original PR, but the gist is...

Invoke and Fabric tasks operate on fundamentally different execution environments, and their contexts should not be interchangeable. While you *may* be able to get away with running an Invoke task with a Fabric `Connection`, the inverse is not true - an Invoke `Context` cannot be promoted into a `Connection`. 

The primary change is how the `Connection` extends the `Context`, moving from an inheritance relationship to composition. Instead of the `Connection` being interchangeable, it should contain  a `Context` that is suitable for use with Invoke tasks.

One benefit is this simplifies the API for managing local vs remote actions. eg, because of the composed `.local` context, it would not be necessary to have both the `cd`/`lcd`, `run`/`local`, and other pairs of remote/local variants. Instead, the `Connection` and `Context` would have their separately defined APIs. eg, 

```python
with conn.cd('...'):
    with conn.local.cd('...'):
        conn.local.run('...')
    conn.run('...')
```

This PR also introduces a new Fabric `task` decorator (with Invoke's `task` imported as `local_task`), which expect their associated context type. e.g., it would not be possible to accidentally provide an Invoke context to a Fabric task, and a Fabric connection to an Invoke task. Note that these changes are dependent on pyinvoke/invoke#507.

The proposed usage would look something like:

```python
from fabric import task, local_task


@local_task
def build(ctx):
    with ctx.cd('/project/dir'):
        ctx.run('build > artifact.zip')


@task
def deploy(conn):
    build(conn.local)

    with conn.cd('/remote/path'), conn.local.cd('/project/dir'):
        conn.put(remote_path='build.zip', local_path='artifact.zip')
```