### PR TITLE
Rupatro/invoke fabric with m flag

### DIFF
--- a/fabric/__main__.py
+++ b/fabric/__main__.py
@@ -4,6 +4,6 @@ package as a script
 Usage: python -m fabric
 '''
 
-from .main import program 
+from .main import program
 
 program.run()

--- a/fabric/__main__.py
+++ b/fabric/__main__.py
@@ -1,0 +1,9 @@
+'''
+This code provides the ability to run fabric
+package as a script
+Usage: python -m fabric
+'''
+
+from .main import program 
+
+program.run()

--- a/sites/www/changelog.rst
+++ b/sites/www/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 .. note::
     Looking for the Fabric 1.x changelog? See :doc:`/changelog-v1`.
 
+- :feature: `-` Invoke fabric as a script using m flag; python -m fabric.
 - :support:`1761 backported` Integration tests were never added to Travis or
   ported to pytest before 2.0's release; this has been addressed.
 - :support:`1759 backported` Apply the ``black`` code formatter to the codebase

--- a/sites/www/changelog.rst
+++ b/sites/www/changelog.rst
@@ -5,7 +5,6 @@ Changelog
 .. note::
     Looking for the Fabric 1.x changelog? See :doc:`/changelog-v1`.
 
-- :feature: `-` Invoke fabric as a script using m flag; python -m fabric.
 - :support:`1761 backported` Integration tests were never added to Travis or
   ported to pytest before 2.0's release; this has been addressed.
 - :support:`1759 backported` Apply the ``black`` code formatter to the codebase

--- a/tests/main.py
+++ b/tests/main.py
@@ -263,7 +263,6 @@ Invoke .+
             # Temporary disable of capture is required to be able to
             # read the fabric module on invoke.run(). Thus, capsys.disabled()
             with capsys.disabled():
-                output = _run_fab_as_module("python -m fabric --version", 
+                output = _run_fab_as_module("python -m fabric --version",
                         hide='out')
                 assert re.match(expected_output, output.stdout)
-

--- a/tests/main.py
+++ b/tests/main.py
@@ -4,8 +4,10 @@ Tests concerned with the ``fab`` tool & how it overrides Invoke defaults.
 
 import os
 import sys
+import re
 
 from invoke.util import cd
+from invoke import run as _run_fab_as_module
 from mock import patch
 import pytest  # because WHY would you expose @skip normally? -_-
 from pytest_relaxed import raises
@@ -250,3 +252,18 @@ Third!
                 value="mypassphrase",
                 prompt="Enter passphrase for use unlocking SSH keys: ",
             )
+
+    class invoke_fab_as_python_module:
+        def check_version_on_invoking_fab_as_module(self, capsys):
+            expected_output = r"""
+Fabric .+
+Paramiko .+
+Invoke .+
+""".strip()
+            # Temporary disable of capture is required to be able to
+            # read the fabric module on invoke.run(). Thus, capsys.disabled()
+            with capsys.disabled():
+                output = _run_fab_as_module("python -m fabric --version", 
+                        hide='out')
+                assert re.match(expected_output, output.stdout)
+


### PR DESCRIPTION
Added __main__.py to enable python -m fabric functionality.
Added test case that checks version of fabric
Updated changelog.rst