### PR TITLE
Support GSS-API authentication when ssh_config specified

### DIFF
--- a/fabric/connection.py
+++ b/fabric/connection.py
@@ -369,6 +369,10 @@ class Connection(Context):
                 self.ssh_config["identityfile"]
             )
 
+        gss_auth = self.ssh_config.get('gssapiauthentication', None)
+        if gss_auth and gss_auth == 'yes':
+            connect_kwargs['gss_auth'] = True
+
         return connect_kwargs
 
     def __repr__(self):


### PR DESCRIPTION
Pass required parameter for GSS-API to Paramiko when ssh_config have
'GSSAPIAuthentication yes' option.

Fix #1794