### PR TITLE
README example using incorrect string interpolation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ commands remotely over SSH, yielding useful Python objects in return::
 
     >>> from fabric import Connection
     >>> result = Connection('web1.example.com').run('uname -s')
-    >>> msg = "Ran {.command!r} on {.connection.host}, got stdout:\n{.stdout}"
+    >>> msg = "Ran {0.command!r} on {0.connection.host}, got stdout:\n{0.stdout}"
     >>> print(msg.format(result))
     Ran "uname -s" on web1.example.com, got this stdout:
     Linux


### PR DESCRIPTION
To work Properly, without "IndexError: tuple index out of range" Closes fabric/fabric#1777