### PR TITLE
Dependent tasks are now executed per host.

### DIFF
--- a/fabric/executor.py
+++ b/fabric/executor.py
@@ -23,8 +23,7 @@ class FabExecutor(Executor):
             # handle intersect of dependencies+parameterization, just becomes
             # 'honor that new feature of Invoke')
             # TODO: roles, other non-runtime host parameterizations, etc
-            # Pre-tasks get added only once, not once per host.
-            ret.extend(self.expand_calls(call.pre, apply_hosts=False))
+            ret.extend(self.expand_calls(call.pre, apply_hosts=apply_hosts))
             # Main task, per host
             for host in hosts:
                 ret.append(self.parameterize(call, host))
@@ -32,8 +31,7 @@ class FabExecutor(Executor):
             # TODO: no tests for this branch?
             if not hosts:
                 ret.append(call)
-            # Post-tasks added once, not once per host.
-            ret.extend(self.expand_calls(call.post, apply_hosts=False))
+            ret.extend(self.expand_calls(call.post, apply_hosts=apply_hosts))
         # Add remainder as anonymous task
         if self.core.remainder:
             # TODO: this will need to change once there are more options for

--- a/tests/_support/fabfile.py
+++ b/tests/_support/fabfile.py
@@ -62,12 +62,18 @@ def expect_identities(c):
 
 @task
 def first(c):
-    print("First!")
+    if hasattr(c, 'host'):
+        print("First: {}".format(c.host))
+    else:
+        print("First!")
 
 
 @task
 def third(c):
-    print("Third!")
+    if hasattr(c, 'host'):
+        print("Third: {}".format(c.host))
+    else:
+        print("Third!")
 
 
 @task(pre=[first], post=[third])

--- a/tests/main.py
+++ b/tests/main.py
@@ -181,11 +181,15 @@ Available tasks:
                 # Expect pre once, 3x main, post once, as opposed to e.g. both
                 # pre and main task
                 expected = """
-First!
+First: hostA
+First: hostB
+First: hostC
 Second: hostA
 Second: hostB
 Second: hostC
-Third!
+Third: hostA
+Third: hostB
+Third: hostC
 """.lstrip()
                 assert output == expected
 


### PR DESCRIPTION
The run() and sudo() methods on a Connection give the expectation that the command will be run on the target host(s). However if a task is specified as a pre or post dependency then the command is run on the machine where the fab command was run.

This PR modifies the calls in the Executor.expand_calls() method to pass the value of allow_hosts to any dependent tasks. The result is that instead of the dependent tasks being executed only once on source machine they are executed on each target host.