### PR TITLE
Only add remainder task when applying hosts

### DIFF
--- a/fabric/executor.py
+++ b/fabric/executor.py
@@ -35,7 +35,7 @@ class FabExecutor(Executor):
             # Post-tasks added once, not once per host.
             ret.extend(self.expand_calls(call.post, apply_hosts=False))
         # Add remainder as anonymous task
-        if self.core.remainder:
+        if self.core.remainder and apply_hosts:
             # TODO: this will need to change once there are more options for
             # setting host lists besides "-H or 100% within-task"
             if not hosts:


### PR DESCRIPTION
Fabric CLI fails to complete any tasks when a remainder is specified after tasks. These work:
```
fab -H host1 task1
fab -H host1 -- 'echo hello'
``` 
but this does not:
```
fab -H host1 task1 -- 'echo hello'
```
failing with:
```
Traceback (most recent call last):
  File "/usr/local/bin/fab", line 11, in <module>
    sys.exit(program.run())
  File "/usr/local/lib/python2.7/site-packages/invoke/program.py", line 363, in run
    self.execute()
  File "/usr/local/lib/python2.7/site-packages/invoke/program.py", line 532, in execute
    executor.execute(*self.tasks)
  File "/usr/local/lib/python2.7/site-packages/invoke/executor.py", line 95, in execute
    expanded = self.expand_calls(calls)
  File "/usr/local/lib/python2.7/site-packages/fabric/executor.py", line 27, in expand_calls
    ret.extend(self.expand_calls(call.pre, apply_hosts=False))
  File "/usr/local/lib/python2.7/site-packages/fabric/executor.py", line 43, in expand_calls
    "Was told to run a command, but not given any hosts to run it on!"  # noqa
fabric.exceptions.NothingToDo: Was told to run a command, but not given any hosts to run it on!
```

This is because `self.core.remainder` is not None, but the `apply_hosts` parameter is set to False when appending `pre` and `post` tasks, so there are no hosts to run the remainder on and this errors out. 

My quick and dirty solution is to not do the remainder if `apply_hosts` is false, although I'm not sure that is the best long term solution. Putting this up here for your consideration. Will update with tests/changelog if you think it's appropriate.