### PR TITLE
Handle merging of string key_filename values from connect_kwargs

### DIFF
--- a/fabric/connection.py
+++ b/fabric/connection.py
@@ -339,6 +339,11 @@ class Connection(Context):
         self.transport = None
 
     def resolve_connect_kwargs(self, connect_kwargs):
+        if connect_kwargs and "key_filename" in connect_kwargs:
+            key_filename = connect_kwargs["key_filename"]
+            if isinstance(key_filename, string_types):
+                connect_kwargs["key_filename"] = [key_filename]
+
         # Grab connect_kwargs from config if not explicitly given.
         if connect_kwargs is None:
             # TODO: is it better to pre-empt conflicts w/ manually-handled

--- a/tests/connection.py
+++ b/tests/connection.py
@@ -713,6 +713,18 @@ class Connection_:
                     ],
                     id="All sources",
                 ),
+                param(
+                    True,
+                    True,
+                    "string",
+                    [
+                        "configured.key",
+                        "kwarg.key",
+                        "ssh-config-B.key",
+                        "ssh-config-A.key",
+                    ],
+                    id="All sources, kwarg (string)",
+                ),
                 param(False, False, False, [], id="No sources"),
                 param(
                     True,
@@ -736,6 +748,13 @@ class Connection_:
                     id="Connection kwarg only",
                 ),
                 param(
+                    False,
+                    False,
+                    "string",
+                    ["kwarg.key"],
+                    id="Connection kwarg (string) only",
+                ),
+                param(
                     True,
                     True,
                     False,
@@ -750,11 +769,25 @@ class Connection_:
                     id="ssh_config + kwarg, no Invoke-level config",
                 ),
                 param(
+                    True,
+                    False,
+                    "string",
+                    ["kwarg.key", "ssh-config-B.key", "ssh-config-A.key"],
+                    id="ssh_config + kwarg (string), no Invoke-level config",
+                ),
+                param(
                     False,
                     True,
                     True,
                     ["configured.key", "kwarg.key"],
                     id="Invoke-level config + kwarg, no ssh_config",
+                ),
+                param(
+                    False,
+                    True,
+                    "string",
+                    ["configured.key", "kwarg.key"],
+                    id="Invoke-level config + kwarg (string), no ssh_config",
                 ),
             ],
         )
@@ -777,7 +810,12 @@ class Connection_:
             connect_kwargs = {}
             if kwarg:
                 # Stitch in connect_kwargs value
-                connect_kwargs = {"key_filename": ["kwarg.key"]}
+                if kwarg == "string":
+                    key_filename = "kwarg.key"
+                else:
+                    key_filename = ["kwarg.key"]
+                connect_kwargs = {"key_filename": key_filename}
+
             # Tie in all sources that were configured & open()
             Connection(
                 "runtime", config=conf, connect_kwargs=connect_kwargs


### PR DESCRIPTION
Specifying a string value for connect_kwargs["key_filename"], as
described in Connection's docstring, fails when this value is merged
with a value from config.connect_kwargs or ssh_config.  Convert string
values to the list form that resolve_connect_kwargs assumes.

---

I've used the 2.0 branch as the base because that's the default branch.  Please let me know if it'd be better to use master.