### PR TITLE
Support put()/get() with sudo.

### DIFF
--- a/fabric/connection.py
+++ b/fabric/connection.py
@@ -17,6 +17,7 @@ from paramiko.agent import AgentRequestHandler
 from paramiko.client import SSHClient, AutoAddPolicy
 from paramiko.config import SSHConfig
 from paramiko.proxy import ProxyCommand
+from paramiko.sftp_client import SFTPClient
 
 from .config import Config
 from .exceptions import InvalidV1Env
@@ -748,7 +749,7 @@ class Connection(Context):
         return super(Connection, self).run(*args, **kwargs)
 
     @opens
-    def sftp(self):
+    def sftp(self, subsystem=None):
         """
         Return a `~paramiko.sftp_client.SFTPClient` object.
 
@@ -760,8 +761,15 @@ class Connection(Context):
         .. versionadded:: 2.0
         """
         if self._sftp is None:
-            self._sftp = self.client.open_sftp()
-        return self._sftp
+            self._sftp = {}
+        if subsystem not in self._sftp:
+            if subsystem is None:
+                self._sftp[subsystem] = self.client.open_sftp()
+            else:
+                channel = self.create_session()
+                channel.exec_command(subsystem)
+                self._sftp[subsystem] = SFTPClient(channel)
+        return self._sftp[subsystem]
 
     def get(self, *args, **kwargs):
         """

--- a/tests/connection.py
+++ b/tests/connection.py
@@ -1029,8 +1029,9 @@ class Connection_:
             assert Connection("host").sftp() == sentinel
             client.open_sftp.assert_called_with()
 
-        def lazily_caches_result(self, client):
-            sentinel1, sentinel2 = object(), object()
+        @patch("fabric.connection.SFTPClient")
+        def lazily_caches_result(self, SFTPClient, client):
+            sentinel1, sentinel2, sentinel3 = object(), object(), object()
             client.open_sftp.side_effect = [sentinel1, sentinel2]
             cxn = Connection("host")
             first = cxn.sftp()
@@ -1039,6 +1040,12 @@ class Connection_:
             assert first is sentinel1, err.format(first)
             second = cxn.sftp()
             assert second is sentinel1, err.format(second)
+            SFTPClient.return_value = sentinel3
+            subsystem = "/usr/bin/sudo /usr/lib/openssh/sftp-server"
+            third = cxn.sftp(subsystem=subsystem)
+            assert third is sentinel3, err.format(third)
+            fourth = cxn.sftp(subsystem=subsystem)
+            assert fourth is sentinel3, err.format(fourth)
 
     class get:
         @patch("fabric.connection.Transfer")


### PR DESCRIPTION
Requires passwordless sudo access on remote.
Also you must know the path to the sftp subsystem on the remote.

Similar to:

`sftp -s "sudo /usr/lib/openssh/sftp-server" user@machine`

```python
from StringIO import StringIO
from fabric import task


@task
def putsudo(c):
    c.put(StringIO("fab put sudo"), "/root/fabsudo.txt", subsystem="/usr/bin/sudo /usr/lib/openssh/sftp-server")
```