### PR TITLE
Fixed "Socket is closed" error when transferring files with new connection

### DIFF
--- a/fabric/connection.py
+++ b/fabric/connection.py
@@ -686,6 +686,7 @@ class Connection(Context):
             self.client.close()
             if self.forward_agent and self._agent_handler is not None:
                 self._agent_handler.close()
+        self._sftp = None
 
     def __enter__(self):
         return self


### PR DESCRIPTION
`_sftp` being a class variable does not get reset if I create a new Connection after closing an existing connection. The memoisation causes the old `_sftp` to be used which results in an error when transferring files on the new connection. 

This change ensures that the variable is cleared when the connection is closed.