### PR TITLE
Fix description of Connection.put

### DIFF
--- a/fabric/connection.py
+++ b/fabric/connection.py
@@ -776,7 +776,7 @@ class Connection(Context):
 
     def put(self, *args, **kwargs):
         """
-        Put a remote file (or file-like object) to the remote filesystem.
+        Put a local file (or file-like object) to the remote filesystem.
 
         Simply a wrapper for `.Transfer.put`. Please see its documentation for
         all details.


### PR DESCRIPTION
Also the underlying `Transfer.put` has this description:

> Upload a file from the local filesystem to the current connection