### PR TITLE
Expand tilde in _load_ssh_file

### DIFF
--- a/fabric/config.py
+++ b/fabric/config.py
@@ -244,24 +244,23 @@ class Config(InvokeConfig):
         # InvokeConfig.load_files? re: having a _found attribute for each that
         # determines whether to load or skip
         if self._runtime_ssh_path is not None:
-            path = self._runtime_ssh_path
-            # Manually blow up like open() (_load_ssh_file normally doesn't)
-            if not os.path.exists(path):
-                msg = "No such file or directory: {!r}".format(path)
-                raise IOError(errno.ENOENT, msg)
-            self._load_ssh_file(os.path.expanduser(path))
+            self._load_ssh_file(self._runtime_ssh_path, optional=False)
         elif self.load_ssh_configs:
             for path in (self._user_ssh_path, self._system_ssh_path):
-                self._load_ssh_file(os.path.expanduser(path))
+                self._load_ssh_file(path)
 
-    def _load_ssh_file(self, path):
+    def _load_ssh_file(self, path, optional=True):
         """
         Attempt to open and parse an SSH config file at ``path``.
 
-        Does nothing if ``path`` is not a path to a valid file.
+        Does nothing if ``path`` is not a path to a valid file unless
+        ``optional`` is ``False`` in which case `~IOError` is raised. Tilde
+        (``~``) in ``path`` is replaced by current user's home directory via
+        `~os.path.expanduser`.
 
         :returns: ``None``.
         """
+        path = os.path.expanduser(path)
         if os.path.isfile(path):
             old_rules = len(self.base_ssh_config._config)
             with open(path) as fd:
@@ -269,8 +268,12 @@ class Config(InvokeConfig):
             new_rules = len(self.base_ssh_config._config)
             msg = "Loaded {} new ssh_config rules from {!r}"
             debug(msg.format(new_rules - old_rules, path))
-        else:
+        elif optional:
             debug("File not found, skipping")
+        else:
+            # Manually blow up like open()
+            msg = "No such file or directory: {!r}".format(path)
+            raise IOError(errno.ENOENT, msg)
 
     @staticmethod
     def global_defaults():

--- a/tests/config.py
+++ b/tests/config.py
@@ -1,5 +1,5 @@
 import errno
-from os.path import join, expanduser
+from os.path import join
 
 from paramiko.config import SSHConfig
 from invoke.vendor.lexicon import Lexicon
@@ -220,12 +220,12 @@ class ssh_config_loading:
     @patch.object(Config, "_load_ssh_file")
     def when_runtime_path_given_other_paths_are_not_sought(self, method):
         Config(runtime_ssh_path=self._runtime_path)
-        method.assert_called_once_with(self._runtime_path)
+        method.assert_called_once_with(self._runtime_path, optional=False)
 
     @patch.object(Config, "_load_ssh_file")
     def runtime_path_can_be_given_via_config_itself(self, method):
         Config(overrides={"ssh_config_path": self._runtime_path})
-        method.assert_called_once_with(self._runtime_path)
+        method.assert_called_once_with(self._runtime_path, optional=False)
 
     def runtime_path_does_not_die_silently(self):
         try:
@@ -241,7 +241,7 @@ class ssh_config_loading:
     def default_file_paths_match_openssh(self, method):
         Config()
         method.assert_has_calls(
-            [call(expanduser("~/.ssh/config")), call("/etc/ssh/ssh_config")]
+            [call("~/.ssh/config"), call("/etc/ssh/ssh_config")]
         )
 
     def system_path_loads_ok(self):
@@ -266,21 +266,6 @@ class ssh_config_loading:
         # Expect the user value (321), not the system one (123)
         assert c.base_ssh_config.lookup("shared")["port"] == "321"
 
-    @patch.object(Config, "_load_ssh_file")
-    @patch("fabric.config.os.path.exists", lambda x: True)
-    def runtime_path_subject_to_user_expansion(self, method):
-        # TODO: other expansion types? no real need for abspath...
-        tilded = "~/probably/not/real/tho"
-        Config(runtime_ssh_path=tilded)
-        method.assert_called_once_with(expanduser(tilded))
-
-    @patch.object(Config, "_load_ssh_file")
-    def user_path_subject_to_user_expansion(self, method):
-        # TODO: other expansion types? no real need for abspath...
-        tilded = "~/probably/not/real/tho"
-        Config(user_ssh_path=tilded)
-        method.assert_any_call(expanduser(tilded))
-
     class core_ssh_load_option_allows_skipping_ssh_config_loading:
         @patch.object(Config, "_load_ssh_file")
         def skips_default_paths(self, method):
@@ -304,7 +289,7 @@ class ssh_config_loading:
             )
             # Expect that loader method did still run (and, as usual, that
             # it did not load any other files)
-            method.assert_called_once_with(self._runtime_path)
+            method.assert_called_once_with(self._runtime_path, optional=False)
 
     class lazy_loading_and_explicit_methods:
         @patch.object(Config, "_load_ssh_file")
@@ -313,4 +298,4 @@ class ssh_config_loading:
             assert not method.called
             c.set_runtime_ssh_path(self._runtime_path)
             c.load_ssh_config()
-            method.assert_called_once_with(self._runtime_path)
+            method.assert_called_once_with(self._runtime_path, optional=False)

--- a/tests/main.py
+++ b/tests/main.py
@@ -139,7 +139,9 @@ Available tasks:
             # that plus a few more pairs of calls against the default files
             # (which is what happens when clone() isn't preserving the
             # already-parsed/loaded SSHConfig)
-            method.assert_called_once_with("ssh_config/runtime.conf")
+            method.assert_called_once_with(
+                "ssh_config/runtime.conf", optional=False
+            )
 
     class hosts_flag_parameterizes_tasks:
         # NOTE: many of these just rely on MockRemote's builtin


### PR DESCRIPTION
```
With tilde character in ssh_config_path Fabric fails in
Config._load_ssh_files() because the following code expands tilde too
late:

    path = self._runtime_ssh_path
    # Manually blow up like open() (_load_ssh_file normally doesn't)
    if not os.path.exists(path):
	msg = "No such file or directory: {0!r}".format(path)
	raise IOError(errno.ENOENT, msg)
    self._load_ssh_file(os.path.expanduser(path))

This commit makes Config._load_ssh_file() expand tilde in path without
altering current behaviour.

I could not figure out how to write a test this change but I can confirm
that it works on my box.
```