### PR TITLE
Change the @needs_host decorator to be aware of the env object changes

### DIFF
--- a/fabric/network.py
+++ b/fabric/network.py
@@ -676,9 +676,9 @@ def needs_host(func):
     commands, this decorator will also end up prompting the user once per
     command (in the case where multiple commands have no hosts set, of course.)
     """
-    from fabric.state import env
     @wraps(func)
     def host_prompting_wrapper(*args, **kwargs):
+        from fabric.state import env
         while not env.get('host_string', False):
             handle_prompt_abort("the target host connection string")
             host_string = raw_input("No hosts found. Please specify (single)"


### PR DESCRIPTION
We do an advanced usage of Fabric 1, with specialized Task sub classes, etc.
We incountred a problem with the env, because we needed to replace it by an extended _AttributeDict object, with namespace-like items and other specific stuffs.

Everything gone ok while loading the config, until we executed a run.

The needs_host decorator had an old "reference" to the state.env object, before its replacement. So the host_string param had not been settted. 

With this modification, the import of the env is done inside the decorators wrapper, so that it uses the current version of the object and not the one at the module loading time.

It works the same when importing the entire state module in place of the env variable, but we prefered this solution.

(Sorry for my english)