### PR TITLE
Fix broken links and use https wherever possible

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,11 +3,11 @@ Welcome to Fabric!
 
 Fabric is a high level Python (2.7, 3.4+) library designed to execute shell
 commands remotely over SSH, yielding useful Python objects in return. It builds
-on top of `Invoke <http://pyinvoke.org>`_ (subprocess command execution and
-command-line features) and `Paramiko <http://paramiko.org>`_ (SSH protocol
+on top of `Invoke <https://www.pyinvoke.org>`_ (subprocess command execution and
+command-line features) and `Paramiko <https://www.paramiko.org>`_ (SSH protocol
 implementation), extending their APIs to complement one another and provide
 additional functionality.
 
 For a high level introduction, including example code, please see
-`our main project website <http://fabfile.org>`_; or for detailed API docs, see
-`the versioned API website <http://docs.fabfile.org>`_.
+`our main project website <https://www.fabfile.org>`_; or for detailed API docs, see
+`the versioned API website <https://docs.fabfile.org>`_.

--- a/fabric/connection.py
+++ b/fabric/connection.py
@@ -359,7 +359,7 @@ class Connection(Context):
             their own arguments. (We `refuse the temptation to guess`_).
 
         .. _refuse the temptation to guess:
-            http://zen-of-python.info/
+            https://zen-of-python.info/
             in-the-face-of-ambiguity-refuse-the-temptation-to-guess.html#12
 
         .. versionchanged:: 2.3

--- a/fabric/testing/fixtures.py
+++ b/fabric/testing/fixtures.py
@@ -7,7 +7,7 @@ fabric[pytest]``.
 
 The simplest way to get these fixtures loaded into your test suite so Pytest
 notices them is to import them into a ``conftest.py`` (`docs
-<http://pytest.readthedocs.io/en/latest/fixture.html#conftest-py-sharing-fixture-functions>`_).
+<https://pytest.readthedocs.io/en/latest/fixture.html#conftest-py-sharing-fixture-functions>`_).
 For example, if you intend to use the `remote` and `client` fixtures::
 
     from fabric.testing.fixtures import client, remote

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ version = _locals["__version__"]
 # Frankenstein long_description: changelog note + README
 long_description = """
 To find out what's new in this version of Fabric, please see `the changelog
-<http://fabfile.org/changelog.html>`_.
+<https://www.fabfile.org/changelog.html>`_.
 
 {}
 """.format(
@@ -66,7 +66,7 @@ setuptools.setup(
     long_description=long_description,
     author="Jeff Forcier",
     author_email="jeff@bitprophet.org",
-    url="http://fabfile.org",
+    url="https://www.fabfile.org",
     install_requires=[
         "invoke>=1.1,<2.0",
         "paramiko>=2.4",

--- a/sites/docs/concepts/networking.rst
+++ b/sites/docs/concepts/networking.rst
@@ -63,7 +63,7 @@ its own username, port number, and so forth. (This includes ``gateway`` itself
 ----------------
 
 The traditional OpenSSH command-line client has long offered a ``ProxyCommand``
-directive (see `man ssh_config <http://man.openbsd.org/ssh_config>`_), which
+directive (see `man ssh_config <https://man.openbsd.org/ssh_config>`_), which
 pipes the inner connection's input and output through an arbitrary local
 subprocess.
 

--- a/sites/docs/conf.py
+++ b/sites/docs/conf.py
@@ -14,12 +14,12 @@ autodoc_default_flags = ["members", "special-members"]
 # under RTD.
 target = join(dirname(__file__), "..", "www", "_build")
 if on_rtd:
-    target = "http://www.fabfile.org/"
+    target = "https://www.fabfile.org/"
 www = (target, None)
 # Intersphinx connection to www site
 intersphinx_mapping.update({"www": www})
 
 # Sister-site links to WWW
 html_theme_options["extra_nav_links"] = {
-    "Main website": "http://www.fabfile.org"
+    "Main website": "https://www.fabfile.org"
 }

--- a/sites/docs/getting-started.rst
+++ b/sites/docs/getting-started.rst
@@ -14,7 +14,7 @@ Fabric composes a couple of other libraries as well as providing its own layer
 on top; user code will most often import from the ``fabric`` package, but
 you'll sometimes import directly from ``invoke`` or ``paramiko`` too:
 
-- `Invoke <https://pyinvoke.org>`_  implements CLI parsing, task organization,
+- `Invoke <https://www.pyinvoke.org>`_  implements CLI parsing, task organization,
   and shell command execution (a generic framework plus specific implementation
   for local commands.)
 
@@ -24,7 +24,7 @@ you'll sometimes import directly from ``invoke`` or ``paramiko`` too:
     - Fabric users will frequently import Invoke objects, in cases where Fabric
       itself has no need to subclass or otherwise modify what Invoke provides.
 
-- `Paramiko <https://paramiko.org>`_ implements low/mid level SSH
+- `Paramiko <https://www.paramiko.org>`_ implements low/mid level SSH
   functionality - SSH and SFTP sessions, key management, etc.
 
     - Fabric mostly uses this under the hood; users will only rarely import
@@ -276,7 +276,7 @@ parameterized with a `.Connection` object from the caller, to encourage reuse::
     def upload_and_unpack(c):
         c.put('myfiles.tgz', '/opt/mydata')
         c.run('tar -C /opt/mydata -xzvf /opt/mydata/myfiles.tgz')
-        
+
 As you'll see below, such functions can be handed to other API methods to
 enable more complex use cases as well.
 
@@ -298,7 +298,7 @@ straightforward approach could be to iterate over a list or tuple of
     web1: Linux
     web2: Linux
     mac1: Darwin
-    
+
 This approach works, but as use cases get more complex it can be
 useful to think of a collection of hosts as a single object. Enter `.Group`, a
 class wrapping one-or-more `.Connection` objects and offering a similar API;

--- a/sites/docs/index.rst
+++ b/sites/docs/index.rst
@@ -4,7 +4,7 @@ Welcome to Fabric's documentation!
 
 This site covers Fabric's usage & API documentation. For basic info on what
 Fabric is, including its public changelog & how the project is maintained,
-please see `the main project website <http://fabfile.org>`_.
+please see `the main project website <https://www.fabfile.org>`_.
 
 Getting started
 ---------------

--- a/sites/shared_conf.py
+++ b/sites/shared_conf.py
@@ -48,20 +48,20 @@ inv_target = join(
     dirname(__file__), "..", "..", "invoke", "sites", "docs", "_build"
 )
 if not on_dev:
-    inv_target = "http://docs.pyinvoke.org/en/latest/"
+    inv_target = "https://docs.pyinvoke.org/en/latest/"
 inv_www_target = join(
     dirname(__file__), "..", "..", "invoke", "sites", "www", "_build"
 )
 if not on_dev:
-    inv_www_target = "http://pyinvoke.org/"
+    inv_www_target = "https://www.pyinvoke.org/"
 # Paramiko (docs)
 para_target = join(
     dirname(__file__), "..", "..", "paramiko", "sites", "docs", "_build"
 )
 if not on_dev:
-    para_target = "http://docs.paramiko.org/en/latest/"
+    para_target = "https://docs.paramiko.org/en/latest/"
 intersphinx_mapping = {
-    "python": ("http://docs.python.org/", None),
+    "python": ("https://docs.python.org/", None),
     "invoke": (inv_target, None),
     "invoke_www": (inv_www_target, None),
     "paramiko": (para_target, None),

--- a/sites/www/changelog-v1.rst
+++ b/sites/www/changelog-v1.rst
@@ -88,7 +88,7 @@ Changelog (1.x)
   .. warning::
     If you are upgrading an existing environment, the install dependencies have
     changed; please see Paramiko's installation docs for details:
-    http://www.paramiko.org/installing.html
+    https://www.paramiko.org/installing.html
 
 * :release:`1.12.1 <2016-12-05>`
 * :release:`1.11.3 <2016-12-05>`

--- a/sites/www/conf.py
+++ b/sites/www/conf.py
@@ -18,8 +18,8 @@ extensions.append("sphinx.ext.intersphinx")
 # under RTD.
 target = join(dirname(__file__), "..", "docs", "_build")
 if on_rtd:
-    target = "http://docs.fabfile.org/en/latest/"
+    target = "https://docs.fabfile.org/en/latest/"
 intersphinx_mapping.update({"docs": (target, None)})
 
 # Sister-site links to API docs
-html_theme_options["extra_nav_links"] = {"API Docs": "http://docs.fabfile.org"}
+html_theme_options["extra_nav_links"] = {"API Docs": "https://docs.fabfile.org"}

--- a/sites/www/contact.rst
+++ b/sites/www/contact.rst
@@ -12,7 +12,7 @@ Mailing list
 ------------
 
 The best way to get help with using Fabric is via the `fab-user mailing list
-<http://lists.nongnu.org/mailman/listinfo/fab-user>`_ (currently hosted at
+<https://lists.nongnu.org/mailman/listinfo/fab-user>`_ (currently hosted at
 ``nongnu.org``.) The Fabric developers do their best to reply promptly, and the
 list contains an active community of other Fabric users and contributors as
 well.

--- a/sites/www/development.rst
+++ b/sites/www/development.rst
@@ -6,7 +6,7 @@ The Fabric development team is headed by `Jeff Forcier
 <http://bitprophet.org>`_, aka ``bitprophet``.  However, dozens of other
 developers pitch in by submitting patches and ideas via `GitHub issues and pull
 requests <https://github.com/fabric/fabric>`_, :ref:`IRC <irc>` or the `mailing
-list <http://lists.nongnu.org/mailman/listinfo/fab-user>`_.
+list <https://lists.nongnu.org/mailman/listinfo/fab-user>`_.
 
 Get the code
 ============
@@ -25,7 +25,7 @@ There are a number of ways to get involved with Fabric:
   `ticket tracker`_ first, though,
   when submitting feature ideas.)
 * **Report bugs or submit feature requests.** We follow `contribution-guide.org
-  <http://contribution-guide.org>`_'s guidelines, so please check them out before
+  <https://www.contribution-guide.org>`_'s guidelines, so please check them out before
   visiting the `ticket tracker`_.
 
 .. _ticket tracker: https://github.com/fabric/fabric/issues

--- a/sites/www/faq.rst
+++ b/sites/www/faq.rst
@@ -13,7 +13,7 @@ your question is not answered here.
 
 .. warning::
     Many questions about shell command execution and task behavior are answered
-    on `Invoke's FAQ page <http://www.pyinvoke.org/faq.html>`_ - please check
+    on `Invoke's FAQ page <https://www.pyinvoke.org/faq.html>`_ - please check
     there also!
 
 

--- a/sites/www/index.rst
+++ b/sites/www/index.rst
@@ -27,8 +27,8 @@ commands remotely over SSH, yielding useful Python objects in return:
     Ran 'uname -s' on web1.example.com, got stdout:
     Linux
 
-It builds on top of `Invoke <http://pyinvoke.org>`_ (subprocess command
-execution and command-line features) and `Paramiko <http://paramiko.org>`_ (SSH
+It builds on top of `Invoke <https://www.pyinvoke.org>`_ (subprocess command
+execution and command-line features) and `Paramiko <https://www.paramiko.org>`_ (SSH
 protocol implementation), extending their APIs to complement one another and
 provide additional functionality.
 
@@ -47,15 +47,15 @@ Core use cases for Fabric include (but are not limited to):
 * Single commands on individual hosts:
 
   .. testsetup:: single-command
-  
+
       from fabric import Connection
       mock = MockRemote()
       mock.expect(out=b"web1")
-  
+
   .. testcleanup:: single-command
-  
+
       mock.stop()
-  
+
   .. doctest:: single-command
 
       >>> result = Connection('web1').run('hostname')
@@ -67,21 +67,21 @@ Core use cases for Fabric include (but are not limited to):
   parallel, etc):
 
   .. testsetup:: multiple-hosts
-  
+
       from fabric import Connection
       mock = MockRemote()
       mock.expect_sessions(
           Session(host='web1', cmd='hostname', out=b'web1\n'),
           Session(host='web2', cmd='hostname', out=b'web2\n'),
       )
-  
+
   .. testcleanup:: multiple-hosts
-  
+
       mock.stop()
-  
+
   .. doctest:: multiple-hosts
 
-      >>> from fabric import SerialGroup     
+      >>> from fabric import SerialGroup
       >>> result = SerialGroup('web1', 'web2').run('hostname')
       web1
       web2
@@ -92,18 +92,18 @@ Core use cases for Fabric include (but are not limited to):
 * Python code blocks (functions/methods) targeted at individual connections:
 
   .. testsetup:: tasks
-  
+
       from fabric import Connection
       mock = MockRemote()
       mock.expect(commands=[
           Command("uname -s", out=b"Linux\n"),
           Command("df -h / | tail -n1 | awk '{print $5}'", out=b'33%\n'),
       ])
-  
+
   .. testcleanup:: tasks
-  
+
       mock.stop()
-  
+
   .. doctest:: tasks
 
       >>> def disk_free(c):
@@ -120,7 +120,7 @@ Core use cases for Fabric include (but are not limited to):
 * Python code blocks on multiple hosts:
 
   .. testsetup:: tasks-on-multiple-hosts
-  
+
       from fabric import Connection, SerialGroup
       mock = MockRemote()
       mock.expect_sessions(
@@ -137,11 +137,11 @@ Core use cases for Fabric include (but are not limited to):
           Command("df -h / | tail -n1 | awk '{print $5}'", out=b'2%\n'),
         ]),
       )
-  
+
   .. testcleanup:: tasks-on-multiple-hosts
-  
+
       mock.stop()
-  
+
   .. doctest:: tasks-on-multiple-hosts
 
       >>> # NOTE: Same code as above!
@@ -172,7 +172,7 @@ binary stub:
 * Multiple tasks may be given in a single CLI session, e.g. ``fab build
   deploy``;
 * Much more - all other Invoke functionality is supported - see `its
-  documentation <http://docs.pyinvoke.org>`_ for details.
+  documentation <https://docs.pyinvoke.org>`_ for details.
 
 I'm a user of Fabric 1, how do I upgrade?
 -----------------------------------------
@@ -190,7 +190,7 @@ changelog, contribution guidelines, development roadmap, news/blog, and so
 forth.
 
 Detailed conceptual and API documentation can be found at our code
-documentation site, `docs.fabfile.org <http://docs.fabfile.org>`_.
+documentation site, `docs.fabfile.org <https://docs.fabfile.org>`_.
 
 
 .. toctree::

--- a/sites/www/installing-1.x.rst
+++ b/sites/www/installing-1.x.rst
@@ -46,7 +46,7 @@ In order for Fabric's installation to succeed, you will need four primary pieces
 
 * the Python programming language;
 * the ``setuptools`` packaging/installation library;
-* the Python `Paramiko <http://paramiko.org>`_ SSH library;
+* the Python `Paramiko <https://www.paramiko.org>`_ SSH library;
 * and Paramiko's dependency, `Cryptography <https://cryptography.io>`_.
 
 and, if using parallel execution mode,
@@ -59,7 +59,7 @@ gotchas.
 Python
 ------
 
-Fabric requires `Python <http://python.org>`_ version 2.5+.
+Fabric requires `Python <https://www.python.org>`_ version 2.5+.
 
 setuptools
 ----------
@@ -88,6 +88,6 @@ details.
     If you encounter this problem, either use ``env.pool_size`` / ``-z`` to
     limit the amount of concurrency, or upgrade to Python
     >=2.6.3.
-    
+
     Python 2.5 is unaffected, as it requires the PyPI version of
     ``multiprocessing``, which is newer than that shipped with Python <2.6.3.

--- a/sites/www/installing.rst
+++ b/sites/www/installing.rst
@@ -103,10 +103,10 @@ Dependencies
 In order for Fabric's installation to succeed, you will need the following:
 
 * the Python programming language, versions 2.7 or 3.4+;
-* the `Invoke <http://pyinvoke.org>`_ command-running and task-execution
+* the `Invoke <https://www.pyinvoke.org>`_ command-running and task-execution
   library;
-* and the `Paramiko <http://paramiko.org>`_ SSH library (as well as its own
-  dependencies; see `its install docs <http://paramiko.org/installing.html>`_.)
+* and the `Paramiko <https://www.paramiko.org>`_ SSH library (as well as its own
+  dependencies; see `its install docs <https://www.paramiko.org/installing.html>`_.)
 
 Development dependencies
 ------------------------
@@ -132,14 +132,14 @@ Source code checkouts
 =====================
 
 The Fabric developers manage the project's source code with the `Git
-<http://git-scm.com>`_ DVCS. To follow Fabric's development via Git instead of
+<https://git-scm.com>`_ DVCS. To follow Fabric's development via Git instead of
 downloading official releases, you have the following options:
 
 * Clone the canonical repository straight from `the Fabric organization's
   repository on Github <https://github.com/fabric/fabric>`_ (cloning
   instructions available on that page).
 * Make your own fork of the Github repository by making a Github account,
-  visiting `fabric/fabric <http://github.com/fabric/fabric>`_ and clicking the
+  visiting `fabric/fabric <https://github.com/fabric/fabric>`_ and clicking the
   "fork" button.
 
 .. note::

--- a/sites/www/roadmap.rst
+++ b/sites/www/roadmap.rst
@@ -5,7 +5,7 @@ Development roadmap
 ===================
 
 This document outlines Fabric's intended development path. Please make sure
-you're reading `the latest version <http://fabfile.org/roadmap.html>`_ of this
+you're reading `the latest version <https://www.fabfile.org/roadmap.html>`_ of this
 document, and also see the page about :ref:`upgrading <upgrading>` if you are
 migrating from version 1 to versions 2 or above.
 
@@ -33,8 +33,8 @@ Modern Fabric versions (2+) receive active feature and bugfix development:
 
 .. note::
     Many features that you may use via Fabric will only need development in the
-    libraries Fabric wraps -- `Invoke <http://pyinvoke.org>`_ and `Paramiko
-    <http://paramiko.org>`_ -- and unless Fabric itself needs changes to match,
+    libraries Fabric wraps -- `Invoke <https://www.pyinvoke.org>`_ and `Paramiko
+    <https://www.paramiko.org>`_ -- and unless Fabric itself needs changes to match,
     you can often get new features by upgrading only one of the three. Make
     sure to check the other projects' changelogs periodically!
 

--- a/sites/www/upgrading.rst
+++ b/sites/www/upgrading.rst
@@ -261,7 +261,7 @@ enough users request it or use cases are made that workarounds are
 insufficient.
 
 - **Ported**: available already, possibly renamed or moved (frequently, moved
-  into the `Invoke <http://pyinvoke.org>`_ codebase.)
+  into the `Invoke <https://www.pyinvoke.org>`_ codebase.)
 - **Pending**: would fit, but has not yet been ported, good candidate for a
   patch. *These entries link to the appropriate Github ticket* - please do
   not make new ones!
@@ -912,7 +912,7 @@ Utilities
       - v1 required using a Fabric-specific 'unwrap_tasks' helper function
         somewhere in your Sphinx build pipeline; now you can instead just
         enable the new `invocations.autodoc
-        <http://invocations.readthedocs.io/en/latest/api/autodoc.html>`_ Sphinx
+        <https://invocations.readthedocs.io/en/latest/api/autodoc.html>`_ Sphinx
         mini-plugin in your extensions list; see link for details.
     * - ``network.normalize``, ``denormalize`` and ``parse_host_string``,
         ostensibly internals but sometimes exposed to users for dealing with


### PR DESCRIPTION
I noticed some of the links on http://docs.fabfile.org/en/latest/getting-started.html were broken because of no 'www' on https links. Rather than fix things half-way, I went through the repo and changed everything possible to https and corrected links.

There are still a few regular http: urls left because those urls don't support https:

```
fabric[master]$ rg http:
sites/www/installing.rst
9:Fabric is best installed via `pip <http://pip-installer.org>`_::

sites/www/installing-1.x.rst
16:Fabric is best installed via `pip <http://pip-installer.org>`_; to ensure you

sites/www/development.rst
6:<http://bitprophet.org>`_, aka ``bitprophet``.  However, dozens of other
```

http://pip-installer.org forwards to https://pip.pypa.io/en/stable/ but I didn't want to change the link on you.

Btw, the repository defaults to the 2.0 branch, which was a little confusing. This PR is against master.