### PR TITLE
Broken links in documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ Welcome to Fabric!
 
 Fabric is a high level Python (2.7, 3.4+) library designed to execute shell
 commands remotely over SSH, yielding useful Python objects in return. It builds
-on top of `Invoke <http://pyinvoke.org>`_ (subprocess command execution and
+on top of `Invoke <https://www.pyinvoke.org>`_ (subprocess command execution and
 command-line features) and `Paramiko <http://paramiko.org>`_ (SSH protocol
 implementation), extending their APIs to complement one another and provide
 additional functionality.

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ Welcome to Fabric!
 Fabric is a high level Python (2.7, 3.4+) library designed to execute shell
 commands remotely over SSH, yielding useful Python objects in return. It builds
 on top of `Invoke <https://www.pyinvoke.org>`_ (subprocess command execution and
-command-line features) and `Paramiko <http://paramiko.org>`_ (SSH protocol
+command-line features) and `Paramiko <https://www.paramiko.org>`_ (SSH protocol
 implementation), extending their APIs to complement one another and provide
 additional functionality.
 

--- a/sites/docs/getting-started.rst
+++ b/sites/docs/getting-started.rst
@@ -14,7 +14,7 @@ Fabric composes a couple of other libraries as well as providing its own layer
 on top; user code will most often import from the ``fabric`` package, but
 you'll sometimes import directly from ``invoke`` or ``paramiko`` too:
 
-- `Invoke <https://pyinvoke.org>`_  implements CLI parsing, task organization,
+- `Invoke <https://www.pyinvoke.org>`_  implements CLI parsing, task organization,
   and shell command execution (a generic framework plus specific implementation
   for local commands.)
 

--- a/sites/docs/getting-started.rst
+++ b/sites/docs/getting-started.rst
@@ -24,7 +24,7 @@ you'll sometimes import directly from ``invoke`` or ``paramiko`` too:
     - Fabric users will frequently import Invoke objects, in cases where Fabric
       itself has no need to subclass or otherwise modify what Invoke provides.
 
-- `Paramiko <https://paramiko.org>`_ implements low/mid level SSH
+- `Paramiko <https://www.paramiko.org>`_ implements low/mid level SSH
   functionality - SSH and SFTP sessions, key management, etc.
 
     - Fabric mostly uses this under the hood; users will only rarely import

--- a/sites/shared_conf.py
+++ b/sites/shared_conf.py
@@ -53,7 +53,7 @@ inv_www_target = join(
     dirname(__file__), "..", "..", "invoke", "sites", "www", "_build"
 )
 if not on_dev:
-    inv_www_target = "http://pyinvoke.org/"
+    inv_www_target = "https://www.pyinvoke.org/"
 # Paramiko (docs)
 para_target = join(
     dirname(__file__), "..", "..", "paramiko", "sites", "docs", "_build"

--- a/sites/www/changelog-v1.rst
+++ b/sites/www/changelog-v1.rst
@@ -88,7 +88,7 @@ Changelog (1.x)
   .. warning::
     If you are upgrading an existing environment, the install dependencies have
     changed; please see Paramiko's installation docs for details:
-    http://www.paramiko.org/installing.html
+    https://www.paramiko.org/installing.html
 
 * :release:`1.12.1 <2016-12-05>`
 * :release:`1.11.3 <2016-12-05>`

--- a/sites/www/faq.rst
+++ b/sites/www/faq.rst
@@ -13,7 +13,7 @@ your question is not answered here.
 
 .. warning::
     Many questions about shell command execution and task behavior are answered
-    on `Invoke's FAQ page <http://www.pyinvoke.org/faq.html>`_ - please check
+    on `Invoke's FAQ page <https://www.pyinvoke.org/faq.html>`_ - please check
     there also!
 
 

--- a/sites/www/index.rst
+++ b/sites/www/index.rst
@@ -28,7 +28,7 @@ commands remotely over SSH, yielding useful Python objects in return:
     Linux
 
 It builds on top of `Invoke <https://www.pyinvoke.org>`_ (subprocess command
-execution and command-line features) and `Paramiko <http://paramiko.org>`_ (SSH
+execution and command-line features) and `Paramiko <https://www.paramiko.org>`_ (SSH
 protocol implementation), extending their APIs to complement one another and
 provide additional functionality.
 

--- a/sites/www/index.rst
+++ b/sites/www/index.rst
@@ -27,7 +27,7 @@ commands remotely over SSH, yielding useful Python objects in return:
     Ran 'uname -s' on web1.example.com, got stdout:
     Linux
 
-It builds on top of `Invoke <http://pyinvoke.org>`_ (subprocess command
+It builds on top of `Invoke <https://www.pyinvoke.org>`_ (subprocess command
 execution and command-line features) and `Paramiko <http://paramiko.org>`_ (SSH
 protocol implementation), extending their APIs to complement one another and
 provide additional functionality.

--- a/sites/www/installing-1.x.rst
+++ b/sites/www/installing-1.x.rst
@@ -46,7 +46,7 @@ In order for Fabric's installation to succeed, you will need four primary pieces
 
 * the Python programming language;
 * the ``setuptools`` packaging/installation library;
-* the Python `Paramiko <http://paramiko.org>`_ SSH library;
+* the Python `Paramiko <https://www.paramiko.org>`_ SSH library;
 * and Paramiko's dependency, `Cryptography <https://cryptography.io>`_.
 
 and, if using parallel execution mode,

--- a/sites/www/installing.rst
+++ b/sites/www/installing.rst
@@ -105,8 +105,8 @@ In order for Fabric's installation to succeed, you will need the following:
 * the Python programming language, versions 2.7 or 3.4+;
 * the `Invoke <https://www.pyinvoke.org>`_ command-running and task-execution
   library;
-* and the `Paramiko <http://paramiko.org>`_ SSH library (as well as its own
-  dependencies; see `its install docs <http://paramiko.org/installing.html>`_.)
+* and the `Paramiko <https://www.paramiko.org>`_ SSH library (as well as its own
+  dependencies; see `its install docs <https://www.paramiko.org/installing.html>`_.)
 
 Development dependencies
 ------------------------

--- a/sites/www/installing.rst
+++ b/sites/www/installing.rst
@@ -103,7 +103,7 @@ Dependencies
 In order for Fabric's installation to succeed, you will need the following:
 
 * the Python programming language, versions 2.7 or 3.4+;
-* the `Invoke <http://pyinvoke.org>`_ command-running and task-execution
+* the `Invoke <https://www.pyinvoke.org>`_ command-running and task-execution
   library;
 * and the `Paramiko <http://paramiko.org>`_ SSH library (as well as its own
   dependencies; see `its install docs <http://paramiko.org/installing.html>`_.)

--- a/sites/www/roadmap.rst
+++ b/sites/www/roadmap.rst
@@ -34,7 +34,7 @@ Modern Fabric versions (2+) receive active feature and bugfix development:
 .. note::
     Many features that you may use via Fabric will only need development in the
     libraries Fabric wraps -- `Invoke <https://www.pyinvoke.org>`_ and `Paramiko
-    <http://paramiko.org>`_ -- and unless Fabric itself needs changes to match,
+    <https://www.paramiko.org>`_ -- and unless Fabric itself needs changes to match,
     you can often get new features by upgrading only one of the three. Make
     sure to check the other projects' changelogs periodically!
 

--- a/sites/www/roadmap.rst
+++ b/sites/www/roadmap.rst
@@ -33,7 +33,7 @@ Modern Fabric versions (2+) receive active feature and bugfix development:
 
 .. note::
     Many features that you may use via Fabric will only need development in the
-    libraries Fabric wraps -- `Invoke <http://pyinvoke.org>`_ and `Paramiko
+    libraries Fabric wraps -- `Invoke <https://www.pyinvoke.org>`_ and `Paramiko
     <http://paramiko.org>`_ -- and unless Fabric itself needs changes to match,
     you can often get new features by upgrading only one of the three. Make
     sure to check the other projects' changelogs periodically!

--- a/sites/www/upgrading.rst
+++ b/sites/www/upgrading.rst
@@ -261,7 +261,7 @@ enough users request it or use cases are made that workarounds are
 insufficient.
 
 - **Ported**: available already, possibly renamed or moved (frequently, moved
-  into the `Invoke <http://pyinvoke.org>`_ codebase.)
+  into the `Invoke <https://www.pyinvoke.org>`_ codebase.)
 - **Pending**: would fit, but has not yet been ported, good candidate for a
   patch. *These entries link to the appropriate Github ticket* - please do
   not make new ones!


### PR DESCRIPTION
Scattered throughout the documentation are a handful of broken links to both paramiko.org and pyinvoke.org. After some investigation it turns out that this is because both URLs https://paramiko.org and https://pyinvoke.org fail to connect. There is also an inconsistent usage of http and https throughout. I ran a simple find and replace to normalize all links to both domains to use https and the www subdomain to avoid any problems.