### PR TITLE
Limit the cryptography package version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setuptools.setup(
     install_requires=[
         "invoke>=1.0,<2.0",
         "paramiko>=2.4",
-        "cryptography>=1.1",
+        "cryptography>=1.1,<=2.4.2",
     ],
     packages=packages,
     entry_points={


### PR DESCRIPTION
There will be some warning message raised if the version of cryptography >= 2.5, like 

```
home/ping/.virtualenvs/mtdpeloy/lib/python2.7/site-packages/paramiko/kex_ecdh_nist.py:39: CryptographyDeprecationWarning: encode_point has been deprecated on EllipticCurvePublicNumbers and will be removed in a 
future version. Please use EllipticCurvePublicKey.public_bytes to obtain both compressed and uncompressed point encoding.                                                                                          
  m.add_string(self.Q_C.public_numbers().encode_point())                                                                                                                                                           
/home/ping/.virtualenvs/mtdpeloy/lib/python2.7/site-packages/paramiko/kex_ecdh_nist.py:96: CryptographyDeprecationWarning: Support for unsafe construction of public numbers from encoded data will be removed in a
 future version. Please use EllipticCurvePublicKey.from_encoded_point                                                                                                                                              
  self.curve, Q_S_bytes                                                                                                                                                                                            
/home/ping/.virtualenvs/mtdpeloy/lib/python2.7/site-packages/paramiko/kex_ecdh_nist.py:111: CryptographyDeprecationWarning: encode_point has been deprecated on EllipticCurvePublicNumbers and will be removed in a
 future version. Please use EllipticCurvePublicKey.public_bytes to obtain both compressed and uncompressed point encoding.                                                                                         
  hm.add_string(self.Q_C.public_numbers().encode_point())
```