### PR TITLE
Fixes #1948 - Removes mentions of scp

### DIFF
--- a/fabric/transfer.py
+++ b/fabric/transfer.py
@@ -1,5 +1,5 @@
 """
-File transfer via SFTP and/or SCP.
+File transfer via SFTP.
 """
 
 import os
@@ -64,7 +64,7 @@ class Transfer(object):
 
             **If a string is given**, it should be a path to a local directory
             or file and is subject to similar behavior as that seen by common
-            Unix utilities or OpenSSH's ``sftp`` or ``scp`` tools.
+            Unix utilities or OpenSSH's ``sftp`` tool.
 
             For example, if the local path is a directory, the remote path's
             base filename will be added onto it (so ``get('foo/bar/file.txt',

--- a/sites/docs/getting-started.rst
+++ b/sites/docs/getting-started.rst
@@ -253,7 +253,7 @@ For example, say you had an archive file you wanted to upload:
     >>> print("Uploaded {0.local} to {0.remote}".format(result))
     Uploaded /local/myfiles.tgz to /opt/mydata/
 
-These methods typically follow the behavior of ``cp`` and ``scp``/``sftp`` in
+These methods typically follow the behavior of ``cp`` and ``sftp`` in
 terms of argument evaluation - for example, in the above snippet, we omitted
 the filename part of the remote path argument.
 


### PR DESCRIPTION
The documentation mentions scp in a couple of places, but scp is not working. This removes the text to avoid confusion for users.