### PR TITLE
Implement file tranfers on group class

### DIFF
--- a/fabric/connection.py
+++ b/fabric/connection.py
@@ -880,3 +880,6 @@ class Connection(Context):
             self.transport.cancel_port_forward(
                 address=remote_host, port=remote_port
             )
+
+    def is_remote_dir(self, path):
+        return Transfer(self).is_remote_dir(path)

--- a/fabric/group.py
+++ b/fabric/group.py
@@ -120,16 +120,15 @@ class Group(list):
 
     # TODO: mirror Connection's close()?
 
-    def get(self, *args, **kwargs):
+    def get(self, remote):
         """
-        Executes `.Connection.get` on all member `Connections <.Connection>`.
-
-        :returns: a `.GroupResult`.
-
-        .. versionadded:: 2.0
+        TODO: What should the return format be?
+         - GroupResult[str, str]
+         - GroupResult[str, FileIO]
+         - ask for a local directory to write to?
+         - callback
         """
-        # TODO: probably best to suck it up & match actual get() sig?
-        return self._operation('get', *args, **kwargs)
+        raise NotImplementedError()
 
     def put(self, *args, **kwargs):
         """


### PR DESCRIPTION
fixes #2037 

Why?
I'd like to do tranfers to multiple hosts at the same time

What does this PR Do?

It moves the Parallelization for the group classes to a function:
```python
def _operation(self, operation *args, **kwargs):
    pass
```

This operation function is then in charge of executing the operation on all connections. All the methods can now be added to the `Group` class since all those implementations do essentially the same thing: 

Example from the `thread_worker` function:
```python
def thread_worker(cxn, operation, queue, args, kwargs):
    func = getattr(cxn, operation)
    result = func(*args, **kwargs)
    # TODO: namedtuple or attrs object?
    queue.put((cxn, result))
``` 

Example from the `SerialGroup`:
```
func = getattr(cxn, operation)
results[cxn] = func(*args, **kwargs)
```

I'll be making a separate PR for a `GroupTransfer` class so that you can choose whether or not to use that.