### PR TITLE
customizable host key policy

### DIFF
--- a/fabric/connection.py
+++ b/fabric/connection.py
@@ -9,7 +9,7 @@ from decorator import decorator
 from invoke import Context
 from invoke.exceptions import ThreadException
 from paramiko.agent import AgentRequestHandler
-from paramiko.client import SSHClient, AutoAddPolicy
+from paramiko.client import SSHClient, RejectPolicy
 from paramiko.config import SSHConfig
 from paramiko.proxy import ProxyCommand
 
@@ -142,7 +142,7 @@ class Connection(Context):
     transport = None
     _sftp = None
     _agent_handler = None
-    default_host_key_policy = AutoAddPolicy
+    default_host_key_policy = RejectPolicy
 
     @classmethod
     def from_v1(cls, env, **kwargs):

--- a/fabric/connection.py
+++ b/fabric/connection.py
@@ -457,18 +457,8 @@ class Connection(Context):
         self.connect_kwargs = self.resolve_connect_kwargs(connect_kwargs)
 
         #: The `paramiko.client.SSHClient` instance this connection wraps.
-        client = SSHClient()
-        if self.default_host_key_policy is not None:
-            logging.debug('host key policy: %s', self.default_host_key_policy)
-            client.set_missing_host_key_policy(self.default_host_key_policy())
-        known_hosts = self.ssh_config.get('UserKnownHostsFile'.lower(),
-                                          '~/.ssh/known_hosts')
-        logging.debug('loading host keys from %s', known_hosts)
-        # multiple keys, seperated by whitespace, can be provided
-        for filename in [os.path.expanduser(f) for f in known_hosts.split()]:
-            if os.path.exists(filename):
-                client.load_host_keys(filename)
-        self.client = client
+        self.client = SSHClient()
+        self.setup_ssh_client()
 
         #: A convenience handle onto the return value of
         #: ``self.client.get_transport()`` (after connection time).
@@ -479,6 +469,21 @@ class Connection(Context):
         #: Whether to construct remote command lines with env vars prefixed
         #: inline.
         self.inline_ssh_env = inline_ssh_env
+
+    def setup_ssh_client(self):
+        if self.default_host_key_policy is not None:
+            logging.debug("host key policy: %s", self.default_host_key_policy)
+            self.client.set_missing_host_key_policy(
+                self.default_host_key_policy()
+            )
+        known_hosts = self.ssh_config.get(
+            "UserKnownHostsFile".lower(), "~/.ssh/known_hosts"
+        )
+        logging.debug("loading host keys from %s", known_hosts)
+        # multiple keys, seperated by whitespace, can be provided
+        for filename in [os.path.expanduser(f) for f in known_hosts.split()]:
+            if os.path.exists(filename):
+                self.client.load_host_keys(filename)
 
     def resolve_connect_kwargs(self, connect_kwargs):
         # TODO: is it better to pre-empt conflicts w/ manually-handled

--- a/fabric/connection.py
+++ b/fabric/connection.py
@@ -140,6 +140,7 @@ class Connection(Context):
     transport = None
     _sftp = None
     _agent_handler = None
+    default_host_key_policy = AutoAddPolicy
 
     @classmethod
     def from_v1(cls, env, **kwargs):
@@ -455,7 +456,8 @@ class Connection(Context):
 
         #: The `paramiko.client.SSHClient` instance this connection wraps.
         client = SSHClient()
-        client.set_missing_host_key_policy(AutoAddPolicy())
+        if self.default_host_key_policy is not None:
+            client.set_missing_host_key_policy(self.default_host_key_policy())
         self.client = client
 
         #: A convenience handle onto the return value of

--- a/fabric/connection.py
+++ b/fabric/connection.py
@@ -140,7 +140,7 @@ class Connection(Context):
     transport = None
     _sftp = None
     _agent_handler = None
-    default_host_key_policy = AutoAddPolicy
+    default_host_key_policy = None
 
     @classmethod
     def from_v1(cls, env, **kwargs):

--- a/fabric/connection.py
+++ b/fabric/connection.py
@@ -464,7 +464,9 @@ class Connection(Context):
         known_hosts = self.ssh_config.get('UserKnownHostsFile'.lower(),
                                           '~/.ssh/known_hosts')
         logging.debug('loading host keys from %s', known_hosts)
-        client.load_host_keys(os.path.expanduser(known_hosts))
+        # multiple keys, seperated by whitespace, can be provided
+        for filename in known_hosts.split():
+            client.load_host_keys(os.path.expanduser(filename))
         self.client = client
 
         #: A convenience handle onto the return value of

--- a/fabric/connection.py
+++ b/fabric/connection.py
@@ -465,8 +465,9 @@ class Connection(Context):
                                           '~/.ssh/known_hosts')
         logging.debug('loading host keys from %s', known_hosts)
         # multiple keys, seperated by whitespace, can be provided
-        for filename in known_hosts.split():
-            client.load_host_keys(os.path.expanduser(filename))
+        for filename in [os.path.expanduser(f) for f in known_hosts.split()]:
+            if os.path.exists(filename):
+                client.load_host_keys(filename)
         self.client = client
 
         #: A convenience handle onto the return value of

--- a/tests/connection.py
+++ b/tests/connection.py
@@ -245,7 +245,7 @@ class Connection_:
                 Connection("host")
                 Client.assert_called_once_with()
 
-            @patch("fabric.connection.AutoAddPolicy")
+            @patch("fabric.connection.Connection.default_host_key_policy")
             def sets_missing_host_key_policy(self, Policy, client):
                 # TODO: should make the policy configurable early on
                 sentinel = Mock()

--- a/tests/connection.py
+++ b/tests/connection.py
@@ -8,7 +8,7 @@ import socket
 import time
 
 from unittest.mock import patch, Mock, call, ANY
-from paramiko.client import SSHClient, AutoAddPolicy
+from paramiko.client import SSHClient, RejectPolicy
 from paramiko import SSHConfig
 import pytest  # for mark, internal raises
 from pytest import skip, param
@@ -65,7 +65,7 @@ class Connection_:
         def defaults_to_auto_add(self):
             # TODO: change Paramiko API so this isn't a private access
             # TODO: maybe just merge with the __init__ test that is similar
-            assert isinstance(Connection("host").client._policy, AutoAddPolicy)
+            assert isinstance(Connection("host").client._policy, RejectPolicy)
 
     class init:
         "__init__"


### PR DESCRIPTION
The current Fabric code does not check or save SSH host keys at all. This PR fixes the problem by ensuring we properly call the Paramiko SSH keys loader when we create our connection object.

We also load the right UserKnownHosts file based on the ssh_config, which paramiko does not do out of the box.

We might want to push the latter into paramiko, but first it seems to me the default Fabric policy of "everything goes" should b fixed.

Note that this also allows callers to override the AutoAddPolicy that is currently in use.

This should fix #2071

This is a rebase of #2072 on top of master (instead of 2.0, see #1929 for that) and with #1960 merged (instead of #2073) to fix the docs.