### PR TITLE
.travis.yml: The 'sudo' tag is now deprecated in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: python
-sudo: required
-dist: trusty
 cache:
   directories:
     - $HOME/.cache/pip


### PR DESCRIPTION
[Travis are now recommending removing the __sudo__ tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).

"_If you currently specify __sudo: false__ in your __.travis.yml__, we recommend removing that configuration_"

Also, do not hard-code __Trusty__ because it reaches its end-of-life this month.
https://wiki.ubuntu.com/Releases

This is a reroll of #1967.