### PR TITLE
Add a hint to normalize_hosts for CLI users.

### DIFF
--- a/sites/docs/getting-started.rst
+++ b/sites/docs/getting-started.rst
@@ -276,7 +276,7 @@ parameterized with a `.Connection` object from the caller, to encourage reuse::
     def upload_and_unpack(c):
         c.put('myfiles.tgz', '/opt/mydata')
         c.run('tar -C /opt/mydata -xzvf /opt/mydata/myfiles.tgz')
-        
+
 As you'll see below, such functions can be handed to other API methods to
 enable more complex use cases as well.
 
@@ -298,7 +298,7 @@ straightforward approach could be to iterate over a list or tuple of
     web1: Linux
     web2: Linux
     mac1: Darwin
-    
+
 This approach works, but as use cases get more complex it can be
 useful to think of a collection of hosts as a single object. Enter `.Group`, a
 class wrapping one-or-more `.Connection` objects and offering a similar API;
@@ -431,3 +431,8 @@ than one host, which runs the task multiple times, each time with a different
 `.Connection` instance handed in::
 
     $ fab -H web1,web2,web3 upload_and_unpack
+
+The way a `.Connection` is created from a host string like ``web1`` may be
+customized by overriding `~fabric.executor.Executor.normalize_hosts`. The
+accompanying :doc:`configuration value </concepts/configuration>` is
+``tasks.executor_class``.


### PR DESCRIPTION
Overriding `Executor.normalize_hosts` is a pretty convenient way for expanding host names from shortcuts or faking the `roles` functionality from v1. 

I am using Fabric from the command line to manage several servers with shared tasks. To speed up my CLI workflow I was using `roles` in v1 a lot. Porting to v2 made me trying to extend `Task` and `ConnectionCall` or messing with custom decorators. Finding `normalize_hosts` buried deep down the documentation saved me a lot of code. I ended up with something like: `$ fab -H app-cluster os.update` and then replace `'app-cluster'` with actual IP adresses in `Executor.normalize_hosts`.