### PR TITLE
fix python executable in tests

### DIFF
--- a/tests/main.py
+++ b/tests/main.py
@@ -358,5 +358,5 @@ Fabric .+
 Paramiko .+
 Invoke .+
 """.strip()
-        output = run("python -m fabric --version", hide=True, in_stream=False)
+        output = run(sys.executable + " -m fabric --version", hide=True, in_stream=False)
         assert re.match(expected_output, output.stdout)


### PR DESCRIPTION
When there is only Python 3 present on the system, the "python" binary is not found.