### PR TITLE
add warning that shell option is accepted but ignored

### DIFF
--- a/fabric/connection.py
+++ b/fabric/connection.py
@@ -1,5 +1,6 @@
 from contextlib import contextmanager
 from threading import Event
+from warnings import warn
 
 try:
     from invoke.vendor.six import StringIO
@@ -718,6 +719,11 @@ class Connection(Context):
 
         .. versionadded:: 2.0
         """
+        if 'shell' in kwargs:
+            warn(
+                'Connection.run ignores the shell argument. See upgrade documentation.',
+                DeprecationWarning
+            )
         return self._run(self._remote_runner(), command, **kwargs)
 
     @opens


### PR DESCRIPTION
This PR adds a warning to users that the `shell` option, described in Invoke's documentation, is ignored by Fabric.

This fixes my complaint in #2096.