### PR TITLE
Only include SSH identity files to be used as key_filename if they ex…

### DIFF
--- a/fabric/connection.py
+++ b/fabric/connection.py
@@ -23,6 +23,7 @@ from .config import Config
 from .transfer import Transfer
 from .tunnels import TunnelManager, Tunnel
 
+import os
 
 @decorator
 def opens(method, self, *args, **kwargs):
@@ -362,7 +363,7 @@ class Connection(Context):
         if "identityfile" in self.ssh_config:
             connect_kwargs.setdefault("key_filename", [])
             connect_kwargs["key_filename"].extend(
-                self.ssh_config["identityfile"]
+                [ identity_file for identity_file in self.ssh_config["identityfile"] if os.path.exists(identity_file) ]
             )
 
         return connect_kwargs


### PR DESCRIPTION
We've had a problem when using fabric:

```
Traceback (most recent call last):
  File "/home/hanc/dev/buck-all/support/scotty/scripts/bin/fab/remote_execute.py", line 18, in get_password
    c.open()
  File "/home/hanc/.local/lib/python3.7/site-packages/fabric/connection.py", line 634, in open
    self.client.connect(**kwargs)
  File "/home/hanc/.local/lib/python3.7/site-packages/paramiko/client.py", line 371, in connect
    passphrase,
  File "/home/hanc/.local/lib/python3.7/site-packages/paramiko/client.py", line 596, in _auth
    key = self._key_from_filepath(key_filename, password=passphrase)
  File "/home/hanc/.local/lib/python3.7/site-packages/paramiko/client.py", line 509, in _key_from_filepath
    key = load_private_key_file(key_path, password)
  File "/home/hanc/.local/lib/python3.7/site-packages/paramiko/pkey.py", line 108, in load_private_key_file
    with open(filename, "r") as f:
FileNotFoundError: [Errno 2] No such file or directory: '/home/esemsch.ssh/id_rsa'
```

It turned out that this was in our `/etc/ssh/ssh_config`:

`
  IdentityFile ~/.ssh/id_rsa
`

However, we didn't have the file in our `~/.ssh/config/`.  This works ok with openssh, but was failing with paramiko.  The problem seems to be that paramiko includes the identity files into the key_filename list without checking whether they exist.  This pull request fixes the problem