### PR TITLE
fix documentation for connection with key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,23 @@
 language: python
 sudo: required
-dist: trusty
+dist: Xenial
 cache:
   directories:
     - $HOME/.cache/pip
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
   - "pypy"
-  - "pypy3"
+  - "pypy3.5"
 matrix:
-  # pypy3 (as of 2.4.0) has a wacky arity issue in its source loader. Allow it
-  # to fail until we can test on, and require, PyPy3.3+. See
-  # pyinvoke/invoke#358.
   allow_failures:
-    - python: pypy3
+    - python: pypy
   # Disabled per https://github.com/travis-ci/travis-ci/issues/1696
   # fast_finish: true
 install:
+  - pip install -U pip
   # TODO: real test matrix with at least some cells combining different invoke
   # and/or paramiko versions, released versions, etc
   # Invoke from master for parity
@@ -27,7 +25,7 @@ install:
   # And invocations, ditto
   - "pip install -e git+https://github.com/pyinvoke/invocations#egg=invocations"
   # Paramiko ditto
-  - "pip install -e git+https://github.com/paramiko/paramiko#egg=paramiko"
+  - "pip install paramiko"
   # Self
   - pip install -e .
   # Limit setuptools as some newer versions have Issues(tm). This needs doing

--- a/fabric/connection.py
+++ b/fabric/connection.py
@@ -231,7 +231,7 @@ class Connection(Context):
                     host="hostname",
                     user="admin",
                     connect_kwargs={
-                        "key_filename": "/home/myuser/.ssh/private.key",
+                        "key_filename": ["/home/myuser/.ssh/private.key"],
                     },
                 )
 


### PR DESCRIPTION
key_filename value should be array, other you will get the following error:
```
  File "venv/lib/python3.8/site-packages/fabric/connection.py", line 450, in __init__
    self.connect_kwargs = self.resolve_connect_kwargs(connect_kwargs)
  File "venv/lib/python3.8/site-packages/fabric/connection.py", line 490, in resolve_connect_kwargs
    connect_kwargs["key_filename"].extend(
AttributeError: 'str' object has no attribute 'extend'
```