### PR TITLE
Drop replace_env from global-scope config

### DIFF
--- a/fabric/config.py
+++ b/fabric/config.py
@@ -308,7 +308,6 @@ class Config(InvokeConfig):
             "inline_ssh_env": False,
             "load_ssh_configs": True,
             "port": 22,
-            "run": {"replace_env": True},
             "runners": {"remote": Remote},
             "ssh_config_path": None,
             "tasks": {"collection_name": "fabfile"},

--- a/fabric/runners.py
+++ b/fabric/runners.py
@@ -58,7 +58,7 @@ class Remote(Runner):
         self.channel.exec_command(command)
     
     def run(self, command, **kwargs):
-        kwargs['replace_env'] = True
+        kwargs.setdefault('replace_env', True)
         return Runner.run(self, command, **kwargs)
     
     def read_proc_stdout(self, num_bytes):

--- a/fabric/runners.py
+++ b/fabric/runners.py
@@ -56,7 +56,11 @@ class Remote(Runner):
             else:
                 self.channel.update_environment(env)
         self.channel.exec_command(command)
-
+    
+    def run(self, command, **kwargs):
+        kwargs['replace_env'] = True
+        return Runner.run(self, command, **kwargs)
+    
     def read_proc_stdout(self, num_bytes):
         return self.channel.recv(num_bytes)
 

--- a/sites/docs/concepts/configuration.rst
+++ b/sites/docs/concepts/configuration.rst
@@ -46,9 +46,9 @@ Default configuration values
 Overrides of Invoke-level defaults
 ----------------------------------
 
-- ``run.replace_env``: ``True``, instead of ``False``, so that remote commands
-  run with a 'clean', empty environment instead of inheriting a copy of the
-  current process' environment.
+- ``run.replace_env``: defaults to ``True``, instead of ``False``, so that
+  remote commands run with a 'clean', empty environment instead of inheriting
+  a copy of the current process' environment.
 
   This is for security purposes: leaking local environment data remotely by
   default would be unsanitary. It's also compatible with the behavior of

--- a/tests/config.py
+++ b/tests/config.py
@@ -50,8 +50,6 @@ class Config_:
 
     def overrides_some_Invoke_defaults(self):
         config = Config()
-        # This value defaults to False in Invoke proper.
-        assert config.run.replace_env is True
         assert config.tasks.collection_name == "fabfile"
 
     def uses_Fabric_prefix(self):

--- a/tests/runners.py
+++ b/tests/runners.py
@@ -29,7 +29,18 @@ class Remote_:
     def needs_handle_on_a_Connection(self):
         c = _Connection("host")
         assert Remote(context=c).context is c
-
+    
+    class env:
+        def replaces_when_replace_env_True(self, remote):
+            env = _runner().run(CMD, env={"JUST": "ME"}, replace_env=True).env
+            assert env == {"JUST": "ME"}
+    
+        def augments_when_replace_env_False(self, remote):
+            env = _runner().run(CMD, env={"JUST": "ME"}, replace_env=False).env
+            assert 'PATH' in env # assuming this will be in every test environment
+            assert 'JUST' in env
+            assert env['JUST'] == 'ME'
+    
     class run:
         def calls_expected_paramiko_bits(self, remote):
             # remote mocking makes generic sanity checks like "were


### PR DESCRIPTION
There may be other implications that I'm unaware of, though from my perspective the tests pass and the issue appears to be resolved.

I've removed `run.replace_env` from Fabric's config override, and replaced it with a kwarg override on `fabric.runners.Remote.run`. In some version of Python since 3.6.6, `_winapi.CreateProcess` starts throwing the error `OSError: [WinError 87] The parameter is incorrect` due to missing environment variables. Ensuring that Fabric doesn't interfere with Invoke's local calls (by removing said globally-scoped configuration variables) seems like the right way to achieve this.

Issue: fabric/fabric#2142
See also: 4358f344e5d6b59dc99d954ad8287b4021d0ed81
