### PR TITLE
clarify documentation for Connection.put

### DIFF
--- a/fabric/connection.py
+++ b/fabric/connection.py
@@ -778,7 +778,7 @@ class Connection(Context):
 
     def put(self, *args, **kwargs):
         """
-        Put a remote file (or file-like object) to the remote filesystem.
+        Put a local file (or file-like object) to the remote filesystem.
 
         Simply a wrapper for `.Transfer.put`. Please see its documentation for
         all details.


### PR DESCRIPTION
New pull request against `master` branch.
Original pull request from @dsch: https://github.com/fabric/fabric/pull/2123

> Fix the wrong documentation for Connection.put method.

