### PR TITLE
Local include std streams in error

### DIFF
--- a/fabric/operations.py
+++ b/fabric/operations.py
@@ -1236,7 +1236,12 @@ def local(command, capture=False, shell=None):
     if p.returncode not in env.ok_ret_codes:
         out.failed = True
         msg = "local() encountered an error (return code %s) while executing '%s'" % (p.returncode, command)
-        error(message=msg, stdout=out, stderr=err)
+        # error()'s logic for appending the stdout and stderr to message assumes the caller has already printed
+        # them if they are to-be shown.  While this assumption is correct for run(), it is not for local(capture=True).
+        # So, if capture=True, we temporarily hide stdout and stderr so that error() will think they should
+        # be included in the error message.
+        with settings(hide('stdout', 'stderr') if capture else None):
+            error(message=msg, stdout=out, stderr=err)
     out.succeeded = not out.failed
     # If we were capturing, this will be a string; otherwise it will be None.
     return out

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -8,7 +8,7 @@ import sys
 from contextlib import nested
 from StringIO import StringIO
 
-from nose.tools import ok_, raises
+from nose.tools import ok_, raises, assert_raises
 from fudge import patched_context, with_fakes, Fake
 from fudge.inspector import arg as fudge_arg
 from mock_streams import mock_streams
@@ -1115,6 +1115,14 @@ def test_local_output_and_capture():
                     yield local, "echo 'foo' >/dev/null", capture
                     del local.description
 
+def test_local_captured_error_includes_output():
+    with assert_raises(SystemExit) as cm:
+        # list something that will exist '/' along with something that won't
+        # so that we will have output in stdout as well as stderr
+        local('ls / thisfiledoesnotexist', capture=True)
+    ex = cm.exception
+    assert_contains('Standard output', ex.message)
+    assert_contains('Standard error', ex.message)
 
 class TestRunSudoReturnValues(FabricTest):
     @server()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -96,7 +96,7 @@ def test_abort_message_only_printed_once():
         result = local("python -m fabric.__main__ -f tests/support/aborts.py kaboom", capture=True)
     # When error in #1318 is present, this has an extra "It burns!" at end of
     # stderr string.
-    eq_(result.stderr, "Fatal error: It burns!\n\nAborting.")
+    eq_(result.stderr.count("It burns!"), 1)
 
 @mock_streams('stderr')
 @with_patched_object(output, 'aborts', True)


### PR DESCRIPTION
Whenever I hit an error during `rsync_project()` or `local()`, I'm always annoyed that the stdout and stderr of the command isn't included in the output from fabric.  It forces me to copy/paste the failing command out of the log and rerun it to see what went wrong.  I finally looked at the Fabric 1.14.0 code to see why this is happening. [rsync_project() just ends up using `local()`,](https://github.com/fabric/fabric/blob/1.14.0/fabric/contrib/project.py#L161)  so I'll continue to describe the issue for local() and stop whining about `rsync_project()` but the same behavior is observed there.

When `local(capture=True)` hits a returncode that isn't ok, [it calls error(), passing in the captured stdout and stderr](https://github.com/fabric/fabric/blob/1.14.0/fabric/operations.py#L1239).  However, `error()` [only adds the stdout and stderr to the error message if fabric is configured to `not fabric.state.output.std{out|err}`](https://github.com/fabric/fabric/blob/1.14.0/fabric/utils.py#L354-L357).  That makes no sense when only looking at `local(capture=True)` but when you look at how `run()` calls `error()` it does because `run()` will have already printed the stdout and stderr of the command, obeying `fabric.state.output.std{out|err}`.  Given that `local(capture=True)` will not have printed the stdout and stderr of the command, the call to `error()` from `local(capture=True)` should contextually invert the sense of `fabric.state.output.std{out|err}` so that the error message will include stdout and stderr that is captured and passed to `error()`.