### PR TITLE
Have open_gateway honor connect_timeout for gateway channel creation

### DIFF
--- a/fabric/connection.py
+++ b/fabric/connection.py
@@ -665,8 +665,6 @@ class Connection(Context):
         # needs...
         # TODO: and the inverse? allow users to supply their own socket/like
         # object they got via $WHEREEVER?
-        # TODO: how best to expose timeout param? reuse general connection
-        # timeout from config?
         return self.gateway.transport.open_channel(
             kind="direct-tcpip",
             dest_addr=(self.host, int(self.port)),
@@ -674,6 +672,7 @@ class Connection(Context):
             # correctly encode into a network message. Theoretically Paramiko
             # could auto-interpret None sometime & save us the trouble.
             src_addr=("", 0),
+            timeout=self.connect_timeout,
         )
 
     def close(self):


### PR DESCRIPTION
Without the ability to specify this timeout, behavior can be quite frustrating when your gateway host is reachable but the target destination is not reachable. An example use case spinning up a new EC2 instance and waiting for SSH to stabilize.

I saw the comment about how to best handle timeouts and figured that an explicit kwarg to Connection for the gateway timeout made the most sense, and that it is only used on connection objects that are used for gateways.

If there are any other places to update / tests to run, let me know.