### PR TITLE
Require pathlib2 only where it is needed, i.e., before Python 3.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,11 @@ setuptools.setup(
     author="Jeff Forcier",
     author_email="jeff@bitprophet.org",
     url="http://fabfile.org",
-    install_requires=["invoke>=1.3,<2.0", "paramiko>=2.4", "pathlib2"],
+    install_requires=[
+        "invoke>=1.3,<2.0",
+        "paramiko>=2.4",
+        'pathlib2; python_version < "3.4"',
+    ],
     extras_require={
         "testing": testing_deps,
         "pytest": testing_deps + pytest_deps,


### PR DESCRIPTION
This only changes `setup.py` to conditionalize the `pathlib2` requirement; `fabric/transfer.py` already prefers the standard library’s `pathlib` where it is available:

```python
try:
    from pathlib import Path
except ImportError:
    from pathlib2 import Path
```