### PR TITLE
Use standard library unittest.mock on Python 3.6 and later

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -10,7 +10,7 @@ pytest==3.2.5
 pytest-cov==2.5.1
 six==1.10.0
 # Mock for test mocking
-mock==2.0.0
+mock==2.0.0; python_version < "3.6"
 # Linting!
 flake8==3.6.0
 # Coverage!

--- a/fabric/testing/base.py
+++ b/fabric/testing/base.py
@@ -18,9 +18,13 @@ using them for your own testing purposes: ``pip install fabric[testing]``.
 from itertools import chain, repeat
 from io import BytesIO
 import os
+from sys import version_info
 
 try:
-    from mock import Mock, PropertyMock, call, patch, ANY
+    if version_info >= (3, 6):
+        from unittest.mock import Mock, PropertyMock, call, patch, ANY
+    else:
+        from mock import Mock, PropertyMock, call, patch, ANY
 except ImportError:
     import warnings
 

--- a/fabric/testing/fixtures.py
+++ b/fabric/testing/fixtures.py
@@ -15,9 +15,14 @@ For example, if you intend to use the `remote` and `client` fixtures::
 .. versionadded:: 2.1
 """
 
+from sys import version_info
+
 try:
     from pytest import fixture
-    from mock import patch, Mock
+    if version_info >= (3, 6):
+        from unittest.mock import patch, Mock
+    else:
+        from mock import patch, Mock
 except ImportError:
     import warnings
 

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ To find out what's new in this version of Fabric, please see `the changelog
     open("README.rst").read()
 )
 
-testing_deps = ["mock>=2.0.0,<3.0"]
+testing_deps = ['mock>=2.0.0,<3.0; python_version < "3.6"']
 pytest_deps = ["pytest>=3.2.5,<4.0"]
 
 setuptools.setup(

--- a/tests/config.py
+++ b/tests/config.py
@@ -1,5 +1,6 @@
 import errno
 from os.path import join, expanduser
+from sys import version_info
 
 from paramiko.config import SSHConfig
 from invoke.vendor.lexicon import Lexicon
@@ -7,7 +8,10 @@ from invoke.vendor.lexicon import Lexicon
 from fabric import Config
 from fabric.util import get_local_user
 
-from mock import patch, call
+if version_info >= (3, 6):
+    from unittest.mock import patch, call
+else:
+    from mock import patch, call
 
 from _util import support, faux_v1_env
 

--- a/tests/config.py
+++ b/tests/config.py
@@ -8,12 +8,12 @@ from invoke.vendor.lexicon import Lexicon
 from fabric import Config
 from fabric.util import get_local_user
 
+from _util import support, faux_v1_env
+
 if version_info >= (3, 6):
     from unittest.mock import patch, call
 else:
     from mock import patch, call
-
-from _util import support, faux_v1_env
 
 
 class Config_:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,10 +2,14 @@
 from fabric.testing.fixtures import client, remote, sftp, sftp_objs, transfer
 
 from os.path import isfile, expanduser
+from sys import version_info
 
 from pytest import fixture
 
-from mock import patch
+if version_info >= (3, 6):
+    from unittest.mock import patch
+else:
+    from mock import patch
 
 
 # TODO: does this want to end up in the public fixtures module too?

--- a/tests/connection.py
+++ b/tests/connection.py
@@ -7,9 +7,13 @@ except ImportError:
 import errno
 from os.path import join
 import socket
+from sys import version_info
 import time
 
-from mock import patch, Mock, call, ANY
+if version_info >= (3, 6):
+    from unittest.mock import patch, Mock, call, ANY
+else:
+    from mock import patch, Mock, call, ANY
 from paramiko.client import SSHClient, AutoAddPolicy
 from paramiko import SSHConfig
 import pytest  # for mark

--- a/tests/connection.py
+++ b/tests/connection.py
@@ -10,10 +10,6 @@ import socket
 from sys import version_info
 import time
 
-if version_info >= (3, 6):
-    from unittest.mock import patch, Mock, call, ANY
-else:
-    from mock import patch, Mock, call, ANY
 from paramiko.client import SSHClient, AutoAddPolicy
 from paramiko import SSHConfig
 import pytest  # for mark
@@ -29,6 +25,11 @@ from fabric.exceptions import InvalidV1Env
 from fabric.util import get_local_user
 
 from _util import support, faux_v1_env
+
+if version_info >= (3, 6):
+    from unittest.mock import patch, Mock, call, ANY
+else:
+    from mock import patch, Mock, call, ANY
 
 
 # Remote is woven in as a config default, so must be patched there

--- a/tests/executor.py
+++ b/tests/executor.py
@@ -6,11 +6,12 @@ from fabric.exceptions import NothingToDo
 
 from sys import version_info
 
+from pytest import skip, raises  # noqa
+
 if version_info >= (3, 6):
     from unittest.mock import Mock
 else:
     from mock import Mock
-from pytest import skip, raises  # noqa
 
 
 def _get_executor(hosts_flag=None, hosts_kwarg=None, post=None, remainder=""):

--- a/tests/executor.py
+++ b/tests/executor.py
@@ -4,7 +4,12 @@ from fabric import Executor, Task, Connection
 from fabric.executor import ConnectionCall
 from fabric.exceptions import NothingToDo
 
-from mock import Mock
+from sys import version_info
+
+if version_info >= (3, 6):
+    from unittest.mock import Mock
+else:
+    from mock import Mock
 from pytest import skip, raises  # noqa
 
 

--- a/tests/group.py
+++ b/tests/group.py
@@ -1,14 +1,15 @@
 from sys import version_info
 
-if version_info >= (3, 6):
-    from unittest.mock import Mock, patch, call
-else:
-    from mock import Mock, patch, call
 from pytest import mark, raises
 
 from fabric import Connection, Group, SerialGroup, ThreadingGroup, GroupResult
 from fabric.group import thread_worker
 from fabric.exceptions import GroupException
+
+if version_info >= (3, 6):
+    from unittest.mock import Mock, patch, call
+else:
+    from mock import Mock, patch, call
 
 
 RUNNER_METHODS = ("run", "sudo")

--- a/tests/group.py
+++ b/tests/group.py
@@ -1,4 +1,9 @@
-from mock import Mock, patch, call
+from sys import version_info
+
+if version_info >= (3, 6):
+    from unittest.mock import Mock, patch, call
+else:
+    from mock import Mock, patch, call
 from pytest import mark, raises
 
 from fabric import Connection, Group, SerialGroup, ThreadingGroup, GroupResult

--- a/tests/main.py
+++ b/tests/main.py
@@ -4,11 +4,15 @@ Tests concerned with the ``fab`` tool & how it overrides Invoke defaults.
 
 import os
 import sys
+from sys import version_info
 import re
 
 from invoke import run
 from invoke.util import cd
-from mock import patch
+if version_info >= (3, 6):
+    from unittest.mock import patch
+else:
+    from mock import patch
 import pytest  # because WHY would you expose @skip normally? -_-
 from pytest_relaxed import raises
 

--- a/tests/main.py
+++ b/tests/main.py
@@ -9,10 +9,6 @@ import re
 
 from invoke import run
 from invoke.util import cd
-if version_info >= (3, 6):
-    from unittest.mock import patch
-else:
-    from mock import patch
 import pytest  # because WHY would you expose @skip normally? -_-
 from pytest_relaxed import raises
 
@@ -22,6 +18,11 @@ from fabric.exceptions import NothingToDo
 
 from fabric.testing.base import Session
 from _util import expect, support, config_file, trap
+
+if version_info >= (3, 6):
+    from unittest.mock import patch
+else:
+    from mock import patch
 
 
 # Designate a runtime config file intended for the test environment; it does

--- a/tests/runners.py
+++ b/tests/runners.py
@@ -5,15 +5,16 @@ except ImportError:
 
 from sys import version_info
 
-if version_info >= (3, 6):
-    from unittest.mock import Mock, patch
-else:
-    from mock import Mock, patch
 from pytest import skip  # noqa
 
 from invoke import pty_size, Result
 
 from fabric import Config, Connection, Remote
+
+if version_info >= (3, 6):
+    from unittest.mock import Mock, patch
+else:
+    from mock import Mock, patch
 
 
 # On most systems this will explode if actually executed as a shell command;

--- a/tests/runners.py
+++ b/tests/runners.py
@@ -3,7 +3,12 @@ try:
 except ImportError:
     from six import StringIO
 
-from mock import Mock, patch
+from sys import version_info
+
+if version_info >= (3, 6):
+    from unittest.mock import Mock, patch
+else:
+    from mock import Mock, patch
 from pytest import skip  # noqa
 
 from invoke import pty_size, Result

--- a/tests/task.py
+++ b/tests/task.py
@@ -1,6 +1,11 @@
 # NOTE: named task.py, not tasks.py, to avoid some occasional pytest weirdness
 
-from mock import Mock
+from sys import version_info
+
+if version_info >= (3, 6):
+    from unittest.mock import Mock
+else:
+    from mock import Mock
 from pytest import skip  # noqa
 
 import fabric

--- a/tests/task.py
+++ b/tests/task.py
@@ -2,14 +2,15 @@
 
 from sys import version_info
 
+from pytest import skip  # noqa
+
+import fabric  # noqa: E402
+from fabric.tasks import ConnectionCall
+
 if version_info >= (3, 6):
     from unittest.mock import Mock
 else:
     from mock import Mock
-from pytest import skip  # noqa
-
-import fabric
-from fabric.tasks import ConnectionCall
 
 
 class Task_:

--- a/tests/transfer.py
+++ b/tests/transfer.py
@@ -3,7 +3,12 @@ try:
 except ImportError:
     from six import StringIO
 
-from mock import Mock, call, patch
+from sys import version_info
+
+if version_info >= (3, 6):
+    from unittest.mock import Mock, call, patch
+else:
+    from mock import Mock, call, patch
 from pytest_relaxed import raises
 from pytest import skip  # noqa
 from paramiko import SFTPAttributes

--- a/tests/transfer.py
+++ b/tests/transfer.py
@@ -5,16 +5,17 @@ except ImportError:
 
 from sys import version_info
 
-if version_info >= (3, 6):
-    from unittest.mock import Mock, call, patch
-else:
-    from mock import Mock, call, patch
 from pytest_relaxed import raises
 from pytest import skip  # noqa
 from paramiko import SFTPAttributes
 
 from fabric import Connection
 from fabric.transfer import Transfer
+
+if version_info >= (3, 6):
+    from unittest.mock import Mock, call, patch
+else:
+    from mock import Mock, call, patch
 
 
 # TODO: pull in all edge/corner case tests from fabric v1

--- a/tests/util.py
+++ b/tests/util.py
@@ -2,7 +2,12 @@
 Tests testing the fabric.util module, not utils for the tests!
 """
 
-from mock import patch
+from sys import version_info
+
+if version_info >= (3, 6):
+    from unittest.mock import patch
+else:
+    from mock import patch
 
 from fabric.util import get_local_user
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -2,14 +2,14 @@
 Tests testing the fabric.util module, not utils for the tests!
 """
 
+from fabric.util import get_local_user
+
 from sys import version_info
 
 if version_info >= (3, 6):
     from unittest.mock import patch
 else:
     from mock import patch
-
-from fabric.util import get_local_user
 
 
 # Basically implementation tests, because it's not feasible to do a "real" test


### PR DESCRIPTION
Drop the dependency on PyPI `mock` beginning with Python 3.6, as it is entirely replaced by `unittest.mock` in the standard library.

While `unittest.mock` appeared in Python 3.3, we explicitly check that the Python version is at least 3.6 so that the `assert_called()` and `assert_called_once()` methods are available on the `Mock` class.