### PR TITLE
Fall back to system modules if vendorized ones do not exist

### DIFF
--- a/integration/concurrency.py
+++ b/integration/concurrency.py
@@ -1,7 +1,11 @@
 import codecs
 
-from invoke.vendor.six.moves.queue import Queue
-from invoke.vendor.six.moves import zip_longest
+try:
+    from invoke.vendor.six.moves.queue import Queue
+    from invoke.vendor.six.moves import zip_longest
+except ImportError:
+    from six.moves.queue import Queue
+    from six.moves import zip_longest
 
 from invoke.util import ExceptionHandlingThread
 from pytest import skip

--- a/tests/_util.py
+++ b/tests/_util.py
@@ -3,7 +3,10 @@ import os
 import re
 import sys
 
-from invoke.vendor.lexicon import Lexicon
+try:
+    from invoke.vendor.lexicon import Lexicon
+except ImportError:
+    from lexicon import Lexicon
 from pytest_relaxed import trap
 
 from fabric.main import make_program

--- a/tests/config.py
+++ b/tests/config.py
@@ -2,7 +2,10 @@ import errno
 from os.path import join, expanduser
 
 from paramiko.config import SSHConfig
-from invoke.vendor.lexicon import Lexicon
+try:
+    from invoke.vendor.lexicon import Lexicon
+except ImportError:
+    from lexicon import Lexicon
 
 from fabric import Config
 from fabric.util import get_local_user

--- a/tests/connection.py
+++ b/tests/connection.py
@@ -2,8 +2,10 @@ from itertools import chain, repeat
 
 try:
     from invoke.vendor.six import b
+    from invoke.vendor.lexicon import Lexicon
 except ImportError:
     from six import b
+    from lexicon import Lexicon
 import errno
 from os.path import join
 import socket
@@ -15,7 +17,6 @@ from paramiko import SSHConfig
 import pytest  # for mark
 from pytest import skip, param
 from pytest_relaxed import raises
-from invoke.vendor.lexicon import Lexicon
 
 from invoke.config import Config as InvokeConfig
 from invoke.exceptions import ThreadException


### PR DESCRIPTION
This is the same as https://github.com/fabric/fabric/pull/1745, but unconditional `invoke.vendor.*` imports have slipped in since then.