### PR TITLE
proxy gateway supports timeout #2026

### DIFF
--- a/fabric/connection.py
+++ b/fabric/connection.py
@@ -674,6 +674,7 @@ class Connection(Context):
             # correctly encode into a network message. Theoretically Paramiko
             # could auto-interpret None sometime & save us the trouble.
             src_addr=("", 0),
+            timeout=self.connect_timeout,
         )
 
     def close(self):


### PR DESCRIPTION
If the targeted host is not available while using gateway, connection would stall for 2 min. Connection object with timeout parameter and valid gateway object, It does not respect the timeout. This commit try to solve the underlying issue.  