### PR TITLE
refactor: implement absolute imports

### DIFF
--- a/fabric/__init__.py
+++ b/fabric/__init__.py
@@ -1,7 +1,7 @@
 # flake8: noqa
-from ._version import __version_info__, __version__
-from .connection import Config, Connection
-from .runners import Remote, RemoteShell, Result
-from .group import Group, SerialGroup, ThreadingGroup, GroupResult
-from .tasks import task, Task
-from .executor import Executor
+from fabric._version import __version_info__, __version__
+from fabric.connection import Config, Connection
+from fabric.runners import Remote, RemoteShell, Result
+from fabric.group import Group, SerialGroup, ThreadingGroup, GroupResult
+from fabric.tasks import task, Task
+from fabric.executor import Executor

--- a/fabric/__main__.py
+++ b/fabric/__main__.py
@@ -4,6 +4,6 @@ package as a script
 Usage: python -m fabric
 """
 
-from .main import program
+from fabric.main import program
 
 program.run()

--- a/fabric/config.py
+++ b/fabric/config.py
@@ -5,8 +5,8 @@ import os
 from invoke.config import Config as InvokeConfig, merge_dicts
 from paramiko.config import SSHConfig
 
-from .runners import Remote, RemoteShell
-from .util import get_local_user, debug
+from fabric.runners import Remote, RemoteShell
+from fabric.util import get_local_user, debug
 
 
 class Config(InvokeConfig):

--- a/fabric/connection.py
+++ b/fabric/connection.py
@@ -18,10 +18,10 @@ from paramiko.client import SSHClient, AutoAddPolicy
 from paramiko.config import SSHConfig
 from paramiko.proxy import ProxyCommand
 
-from .config import Config
-from .exceptions import InvalidV1Env
-from .transfer import Transfer
-from .tunnels import TunnelManager, Tunnel
+from fabric.config import Config
+from fabric.exceptions import InvalidV1Env
+from fabric.transfer import Transfer
+from fabric.tunnels import TunnelManager, Tunnel
 
 
 @decorator

--- a/fabric/executor.py
+++ b/fabric/executor.py
@@ -1,9 +1,9 @@
 import invoke
 from invoke import Call, Task
 
-from .tasks import ConnectionCall
-from .exceptions import NothingToDo
-from .util import debug
+from fabric.tasks import ConnectionCall
+from fabric.exceptions import NothingToDo
+from fabric.util import debug
 
 
 class Executor(invoke.Executor):

--- a/fabric/group.py
+++ b/fabric/group.py
@@ -5,8 +5,8 @@ except ImportError:
 
 from invoke.util import ExceptionHandlingThread
 
-from .connection import Connection
-from .exceptions import GroupException
+from fabric.connection import Connection
+from fabric.exceptions import GroupException
 
 
 class Group(list):

--- a/fabric/main.py
+++ b/fabric/main.py
@@ -10,8 +10,8 @@ from invoke import Argument, Collection, Program
 from invoke import __version__ as invoke
 from paramiko import __version__ as paramiko
 
-from . import __version__ as fabric
-from . import Config, Executor
+from fabric import __version__ as fabric
+from fabric import Config, Executor
 
 
 class Fab(Program):

--- a/fabric/tasks.py
+++ b/fabric/tasks.py
@@ -1,6 +1,6 @@
 import invoke
 
-from .connection import Connection
+from fabric.connection import Connection
 
 
 class Task(invoke.Task):

--- a/fabric/testing/fixtures.py
+++ b/fabric/testing/fixtures.py
@@ -28,14 +28,14 @@ except ImportError:
     warnings.warn(warning, ImportWarning)
     raise
 
-from .. import Connection
-from ..transfer import Transfer
+from fabric import Connection
+from fabric.transfer import Transfer
 
 # TODO: if we find a lot of people somehow ending up _with_ pytest but
 # _without_ mock and other deps from testing.base, consider doing the
 # try/except here too. But, really?
 
-from .base import MockRemote, MockSFTP
+from fabric.testing.base import MockRemote, MockSFTP
 
 
 @fixture

--- a/fabric/transfer.py
+++ b/fabric/transfer.py
@@ -11,7 +11,7 @@ try:
 except ImportError:
     from pathlib2 import Path
 
-from .util import debug  # TODO: actual logging! LOL
+from fabric.util import debug  # TODO: actual logging! LOL
 
 # TODO: figure out best way to direct folks seeking rsync, to patchwork's rsync
 # call (which needs updating to use invoke.run() & fab 2 connection methods,


### PR DESCRIPTION
This PR is intended to help improve the security of applications using fabric by using explicit paths.

Relative paths can potentially be exploited my malicious libraries. This coupled with the potential use of sudo capabilities can allow for privilege escalation.

This is due to the module cache being world writable within CPython.