### PR TITLE
Document implications of close() behavior

### DIFF
--- a/fabric/connection.py
+++ b/fabric/connection.py
@@ -681,6 +681,11 @@ class Connection(Context):
         Terminate the network connection to the remote end, if open.
 
         If no connection is open, this method does nothing.
+        
+        Note this does not block until an open connection actually closes. If
+        the SSH server cannot accept multiple connections (e.g. OpenSSH
+        sshd -d) your code will need to wait a few moments before making a
+        second connection.
 
         .. versionadded:: 2.0
         """


### PR DESCRIPTION
Documents that close() doesn't block until the SSH connection actually is ended. Useful info if your SSHd cannot accept multiple connections and you need to immediately follow fabric commands with a separate connection (e.g. rsync).