### PR TITLE
removing old pytest upper limit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ To find out what's new in this version of Fabric, please see `the changelog
 )
 
 testing_deps = ["mock>=2.0.0,<3.0"]
-pytest_deps = ["pytest>=3.2.5,<4.0"]
+pytest_deps = ["pytest>=3.2.5"]
 
 setuptools.setup(
     name=package_name,


### PR DESCRIPTION
I was trying to pull in `pytest-mock` and `pytest-xdist` (since I won't only be using pytest for fabric parts of my code and I'll need these for other things), and they both have lower limits of pytest at 5.0 and 6.2.0.

So, when trying to install fabric's pytest (`fabric[pytest]`) as well I wasn't able to get a version of pytest to match.

![image](https://user-images.githubusercontent.com/10230166/151435012-ece02ad4-abfd-42a5-94b9-f7462275efc7.png)

Pytest 5.0.0 was released in  Jun 28, 2019, so 4.0 is quite an old release. If your comfortable with just removing the upper bounds for pytest, then it should be able to reach a consensus between the packages. So, I just removed the upper bounds with this PR, but if you don't want to do that then you'll have to keep on top of this every time the upper bounds gets old.

Seems like it was probably just put in there since it was the latest major release: https://github.com/fabric/fabric/commit/b98334bdd7de520ac8f6eb9f06444db805341869

Haven't used the project really yet, but seems pretty awesome! Thanks for your hard work!