### PR TITLE
Close SFTP session when Connection is closed

### DIFF
--- a/fabric/connection.py
+++ b/fabric/connection.py
@@ -87,18 +87,18 @@ class Connection(Context):
     - Methods like `run`, `get` etc automatically trigger a call to
       `open` if the connection is not active; users may of course call `open`
       manually if desired.
-    - Connections do not always need to be explicitly closed; much of the
-      time, Paramiko's garbage collection hooks or Python's own shutdown
-      sequence will take care of things. **However**, should you encounter edge
-      cases (for example, sessions hanging on exit) it's helpful to explicitly
-      close connections when you're done with them.
+    - It's best to explicitly close your connections when done using them. This
+      can be accomplished by manually calling `close`, or by using the object
+      as a contextmanager::
 
-      This can be accomplished by manually calling `close`, or by using the
-      object as a contextmanager::
+          with Connection('host') as c:
+             c.run('command')
+             c.put('file')
 
-        with Connection('host') as c:
-            c.run('command')
-            c.put('file')
+      .. warning::
+          While Fabric (and Paramiko) attempt to register connections for
+          automatic garbage collection, it's not currently safe to rely on that
+          feature, as it can lead to end-of-process hangs and similar behavior.
 
     .. note::
         This class rebinds `invoke.context.Context.run` to `.local` so both

--- a/fabric/connection.py
+++ b/fabric/connection.py
@@ -678,12 +678,16 @@ class Connection(Context):
 
     def close(self):
         """
-        Terminate the network connection to the remote end, if open.
+        Terminate the network connection to the remote end, if open. If any SFTP sessions are open, they will also be closed.
 
         If no connection is open, this method does nothing.
 
         .. versionadded:: 2.0
         """
+        if self._sftp:
+            self._sftp.close()
+            self._sftp = None
+        
         if self.is_connected:
             self.client.close()
             if self.forward_agent and self._agent_handler is not None:

--- a/tests/connection.py
+++ b/tests/connection.py
@@ -892,6 +892,24 @@ class Connection_:
             c.close()
             client.close.assert_called_with()
 
+        def calls_SFTPClient_close(self, client):
+            "calls paramiko.SFTPClient.close()"
+            c = Connection("host")
+            c.open()
+            sftp_client = c.sftp()
+            assert c._sftp is not None
+            c.close()
+            assert c._sftp is None
+            sftp_client.close.assert_called_with()
+
+        def calls_SFTPClient_close_not_called_if_not_open(self, client):
+            "calls paramiko.SFTPClient.close()"
+            c = Connection("host")
+            c.open()
+            assert c._sftp is None
+            c.close()
+            assert c._sftp is None
+
         @patch("fabric.connection.AgentRequestHandler")
         def calls_agent_handler_close_if_enabled(self, Handler, client):
             c = Connection("host", forward_agent=True)


### PR DESCRIPTION
If an SFTP session has been opened, ensure it is called and set to `None` when the Connection has been closed.

Fixes #1981 