### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setuptools.setup(
     author_email="jeff@bitprophet.org",
     url="http://fabfile.org",
     project_urls={
-        'Source': 'https://github.com/fabric/fabric',
+        "Source": "https://github.com/fabric/fabric",
     },
     install_requires=["invoke>=1.3,<2.0", "paramiko>=2.4", "pathlib2"],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,9 @@ setuptools.setup(
     author="Jeff Forcier",
     author_email="jeff@bitprophet.org",
     url="http://fabfile.org",
+    project_urls={
+        'Source': 'https://github.com/fabric/fabric',
+    },
     install_requires=["invoke>=1.3,<2.0", "paramiko>=2.4", "pathlib2"],
     extras_require={
         "testing": testing_deps,


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help automation tool find the source code for Requests.

Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)