### PR TITLE
Use sys.executable when testing with -m fabric

### DIFF
--- a/tests/main.py
+++ b/tests/main.py
@@ -358,5 +358,7 @@ Fabric .+
 Paramiko .+
 Invoke .+
 """.strip()
-        output = run("python -m fabric --version", hide=True, in_stream=False)
+        output = run(
+            sys.executable + " -m fabric --version", hide=True, in_stream=False
+        )
         assert re.match(expected_output, output.stdout)


### PR DESCRIPTION
The current test case assumes /usr/bin/python is the current running
Python release, which it may not always be, so make use of
sys.executable to re-exec the interpreter.