### PR TITLE
Add support for unittest.mock

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,7 +9,7 @@ pytest==3.2.5
 pytest-cov==2.5.1
 six==1.10.0
 # Mock for test mocking
-mock==2.0.0
+mock==2.0.0;python_version<='3.3'
 # Formatting!
 flake8==3.6.0
 black==18.6b4

--- a/fabric/testing/base.py
+++ b/fabric/testing/base.py
@@ -20,7 +20,10 @@ from io import BytesIO
 import os
 
 try:
-    from mock import Mock, PropertyMock, call, patch, ANY
+    try:
+        from unittest.mock import Mock, PropertyMock, call, patch, ANY
+    except ImportError:
+        from mock import Mock, PropertyMock, call, patch, ANY
 except ImportError:
     import warnings
 

--- a/fabric/testing/fixtures.py
+++ b/fabric/testing/fixtures.py
@@ -17,7 +17,11 @@ For example, if you intend to use the `remote` and `client` fixtures::
 
 try:
     from pytest import fixture
-    from mock import patch, Mock
+
+    try:
+        from unittest.mock import patch, Mock
+    except ImportError:
+        from mock import patch, Mock
 except ImportError:
     import warnings
 

--- a/setup.py
+++ b/setup.py
@@ -67,8 +67,9 @@ setuptools.setup(
     },
     install_requires=["invoke>=1.3,<2.0", "paramiko>=2.4", "pathlib2"],
     extras_require={
-        "testing": testing_deps,
-        "pytest": testing_deps + pytest_deps,
+        "testing:python_version<='3.3'": testing_deps,
+        "pytest:python_version<='3.3'": testing_deps + pytest_deps,
+        "pytest:python_version>='3.4'": pytest_deps,
     },
     packages=packages,
     entry_points={

--- a/tests/config.py
+++ b/tests/config.py
@@ -8,7 +8,10 @@ from invoke.vendor.lexicon import Lexicon
 from fabric import Config, Remote, RemoteShell
 from fabric.util import get_local_user
 
-from mock import patch, call
+try:
+    from unittest.mock import patch, call
+except ImportError:
+    from mock import patch, call
 
 from _util import support, faux_v1_env
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,10 @@ from os.path import isfile, expanduser
 
 from pytest import fixture
 
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 
 # TODO: does this want to end up in the public fixtures module too?

--- a/tests/connection.py
+++ b/tests/connection.py
@@ -10,7 +10,10 @@ from os.path import join
 import socket
 import time
 
-from mock import patch, Mock, call, ANY
+try:
+    from unittest.mock import patch, Mock, call, ANY
+except ImportError:
+    from mock import patch, Mock, call, ANY
 from paramiko.client import SSHClient, AutoAddPolicy
 from paramiko import SSHConfig
 import pytest  # for mark, internal raises

--- a/tests/executor.py
+++ b/tests/executor.py
@@ -4,7 +4,10 @@ from fabric import Executor, Task, Connection
 from fabric.executor import ConnectionCall
 from fabric.exceptions import NothingToDo
 
-from mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 from pytest import skip, raises  # noqa
 
 

--- a/tests/group.py
+++ b/tests/group.py
@@ -1,4 +1,7 @@
-from mock import Mock, patch, call
+try:
+    from unittest.mock import Mock, patch, call
+except ImportError:
+    from mock import Mock, patch, call
 from pytest import mark, raises
 
 from fabric import Connection, Group, SerialGroup, ThreadingGroup, GroupResult

--- a/tests/main.py
+++ b/tests/main.py
@@ -8,7 +8,11 @@ import re
 
 from invoke import run
 from invoke.util import cd
-from mock import patch
+
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 import pytest  # because WHY would you expose @skip normally? -_-
 from pytest_relaxed import raises
 

--- a/tests/runners.py
+++ b/tests/runners.py
@@ -3,7 +3,10 @@ try:
 except ImportError:
     from six import StringIO
 
-from mock import Mock, patch
+try:
+    from unittest.mock import Mock, patch
+except ImportError:
+    from mock import Mock, patch
 from pytest import skip  # noqa
 
 from invoke import pty_size, Result

--- a/tests/task.py
+++ b/tests/task.py
@@ -1,6 +1,9 @@
 # NOTE: named task.py, not tasks.py, to avoid some occasional pytest weirdness
 
-from mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 from pytest import skip  # noqa
 
 import fabric

--- a/tests/transfer.py
+++ b/tests/transfer.py
@@ -3,7 +3,10 @@ try:
 except ImportError:
     from six import StringIO
 
-from mock import Mock, call, patch
+try:
+    from unittest.mock import Mock, call, patch
+except ImportError:
+    from mock import Mock, call, patch
 from pytest_relaxed import raises
 from pytest import skip  # noqa
 from paramiko import SFTPAttributes

--- a/tests/util.py
+++ b/tests/util.py
@@ -2,7 +2,10 @@
 Tests testing the fabric.util module, not utils for the tests!
 """
 
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 from fabric.util import get_local_user
 


### PR DESCRIPTION
Python from 3.4 has included mock in the unittest module, so to remove
a possibly unneeded external requirement, try and import it from there
first.