### PR TITLE
forward_local() does not work on windows.

### DIFF
--- a/fabric/tunnels.py
+++ b/fabric/tunnels.py
@@ -68,6 +68,9 @@ class TunnelManager(ExceptionHandlingThread):
                 tun_sock, local_addr = sock.accept()
                 # Set TCP_NODELAY to match OpenSSH's forwarding socket behavior
                 tun_sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+            except BlockingIOError:
+                time.sleep(0.01)
+                continue
             except socket.error as e:
                 if e.errno is errno.EAGAIN:
                     # TODO: make configurable


### PR DESCRIPTION
Tunnel.py code should handle BlockingIOError happening on windows when try to call forward_local()

More discussed on the below issue reported. @nitrocalcite found the fix, cudos to him
#2102 