### PR TITLE
Add pytest-relaxed dependency to pytest_deps

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,10 @@ with open(os.path.join(package_name, "_version.py")) as fp:
 version = _locals["__version__"]
 
 testing_deps = ["mock>=2.0.0,<3.0"]
-pytest_deps = ["pytest>=3.2.5,<4.0"]
+pytest_deps = [
+    "pytest>=3.2.5,<4.0",
+    "pytest-relaxed>=1.0.1,<1.1"
+]
 
 setuptools.setup(
     name=package_name,

--- a/setup.py
+++ b/setup.py
@@ -46,10 +46,7 @@ with open(os.path.join(package_name, "_version.py")) as fp:
 version = _locals["__version__"]
 
 testing_deps = ["mock>=2.0.0,<3.0"]
-pytest_deps = [
-    "pytest>=3.2.5,<4.0",
-    "pytest-relaxed>=1.0.1,<1.1"
-]
+pytest_deps = ["pytest>=3.2.5,<4.0", "pytest-relaxed>=1.0.1,<1.1"]
 
 setuptools.setup(
     name=package_name,


### PR DESCRIPTION
This is so that running tests with `pytest` will work after running:

$ pip install -e[pytest]

I have used the same version specifiers that are used in `dev-requirements.txt`.