### PR TITLE
Fix: call parent `stop()` on `Remote` runner

### DIFF
--- a/fabric/runners.py
+++ b/fabric/runners.py
@@ -114,7 +114,7 @@ class Remote(Runner):
         return Result(**kwargs)
 
     def stop(self):
-        super()
+        super().stop()
         if hasattr(self, "channel"):
             self.channel.close()
 


### PR DESCRIPTION
This should resolve #2241 