### PR TITLE
pass Connection.connect_timeout to paramiko open_channel

### DIFF
--- a/fabric/connection.py
+++ b/fabric/connection.py
@@ -676,6 +676,7 @@ class Connection(Context):
         return self.gateway.transport.open_channel(
             kind="direct-tcpip",
             dest_addr=(self.host, int(self.port)),
+            timeout=self.connect_timeout,
             # NOTE: src_addr needs to be 'empty but not None' values to
             # correctly encode into a network message. Theoretically Paramiko
             # could auto-interpret None sometime & save us the trouble.


### PR DESCRIPTION
Working with 3.0.0 yesterday I wasn't able to set timeout on the initial connection. It seems it isn't being passed into paramiko open_channel and adding this one liner give me the correct behavior. 

If this is not the correct fix, let me know and I'll make it then submit a new PR.