### PR TITLE
refactor: use safer log parameters instead of interpolation

### DIFF
--- a/fabric/config.py
+++ b/fabric/config.py
@@ -268,8 +268,11 @@ class Config(InvokeConfig):
             with open(path) as fd:
                 self.base_ssh_config.parse(fd)
             new_rules = len(self.base_ssh_config._config)
-            msg = "Loaded {} new ssh_config rules from {!r}"
-            debug(msg.format(new_rules - old_rules, path))
+            debug(
+                "Loaded %s new ssh_config rules from %r",
+                new_rules - old_rules,
+                path,
+            )
         else:
             debug("File not found, skipping")
 

--- a/fabric/executor.py
+++ b/fabric/executor.py
@@ -111,8 +111,8 @@ class Executor(invoke.Executor):
         :returns:
             `.ConnectionCall`.
         """
-        msg = "Parameterizing {!r} with Connection kwargs {!r}"
-        debug(msg.format(call, connection_init_kwargs))
+        msg = "Parameterizing %r with Connection kwargs %r"
+        debug(msg, call, connection_init_kwargs)
         # Generate a custom ConnectionCall that has init_kwargs (used for
         # creating the Connection at runtime) set to the requested params.
         new_call_kwargs = dict(init_kwargs=connection_init_kwargs)

--- a/fabric/transfer.py
+++ b/fabric/transfer.py
@@ -248,7 +248,7 @@ class Transfer:
                 )
             else:
                 remote = local_base
-                debug("Massaged empty remote path into {!r}".format(remote))
+                debug("Massaged empty remote path into %r", remote)
         elif self.is_remote_dir(remote):
             # non-empty local_base implies a) text file path or b) FLO which
             # had a non-empty .name attribute. huzzah!
@@ -273,8 +273,8 @@ class Transfer:
             self.sftp.getcwd() or self.sftp.normalize("."), remote
         )
         if remote != prejoined_remote:
-            msg = "Massaged relative remote path {!r} into {!r}"
-            debug(msg.format(prejoined_remote, remote))
+            msg = "Massaged relative remote path %r into %r"
+            debug(msg, prejoined_remote, remote)
 
         # Massage local path
         orig_local = local
@@ -282,10 +282,10 @@ class Transfer:
             local = os.path.abspath(local)
             if local != orig_local:
                 debug(
-                    "Massaged relative local path {!r} into {!r}".format(
-                        orig_local, local
-                    )
-                )  # noqa
+                    "Massaged relative local path %r into %r",
+                    orig_local,
+                    local,
+                )
 
         # Run Paramiko-level .put() (side-effects only. womp.)
         # TODO: push some of the path handling into Paramiko; it should be
@@ -295,8 +295,8 @@ class Transfer:
         #
         # If local appears to be a file-like object, use sftp.putfo, not put
         if is_file_like:
-            msg = "Uploading file-like object {!r} to {!r}"
-            debug(msg.format(local, remote))
+            msg = "Uploading file-like object %r to %r"
+            debug(msg, local, remote)
             pointer = local.tell()
             try:
                 local.seek(0)
@@ -304,7 +304,7 @@ class Transfer:
             finally:
                 local.seek(pointer)
         else:
-            debug("Uploading {!r} to {!r}".format(local, remote))
+            debug("Uploading %r to %r", local, remote)
             self.sftp.put(localpath=local, remotepath=remote)
             # Set mode to same as local end
             # TODO: Push this down into SFTPClient sometime (requires backwards

--- a/fabric/util.py
+++ b/fabric/util.py
@@ -1,14 +1,11 @@
 import logging
 import sys
 
-
 # Ape the half-assed logging junk from Invoke, but ensuring the logger reflects
 # our name, not theirs. (Assume most contexts will rely on Invoke itself to
 # literally enable/disable logging, for now.)
 log = logging.getLogger("fabric")
-for x in ("debug",):
-    globals()[x] = getattr(log, x)
-
+debug = log.debug
 
 win32 = sys.platform == "win32"
 


### PR DESCRIPTION
@bitprophet Use parameters for safer logging so that applications wrapping fabric won't be susceptible to log4shell style vulnerabilities. 