### PR TITLE
feat: allow interpolation of original_host in Transfer.get

### DIFF
--- a/fabric/transfer.py
+++ b/fabric/transfer.py
@@ -78,8 +78,8 @@ class Transfer:
             This path will be **interpolated** with some useful parameters,
             using `str.format`:
 
-            - The `.Connection` object's ``host``, ``user`` and ``port``
-              attributes.
+            - The `.Connection` object's ``host``, ``original_host``, ``user``
+              and ``port`` attributes.
             - The ``basename`` and ``dirname`` of the ``remote`` path, as
               derived by `os.path` (specifically, its ``posixpath`` flavor, so
               that the resulting values are useful on remote POSIX-compatible
@@ -138,6 +138,9 @@ class Transfer:
                 host=self.connection.host,
                 user=self.connection.user,
                 port=self.connection.port,
+                original_host=getattr(
+                    self.connection, "original_host", self.connection.host
+                ),
                 dirname=posixpath.dirname(remote),
                 basename=remote_filename,
             )

--- a/tests/transfer.py
+++ b/tests/transfer.py
@@ -91,8 +91,11 @@ class Transfer_:
 
         class local_arg_interpolation:
             def connection_params(self, transfer):
-                result = transfer.get("somefile", "{user}@{host}-{port}")
-                expected = "/local/{}@host-22".format(transfer.connection.user)
+                remote = "{user}@{host}-{original_host}-{port}"
+                result = transfer.get("somefile", remote)
+                expected = "/local/{}@host-host-22".format(
+                    transfer.connection.user
+                )
                 assert result.local == expected
 
             def connection_params_as_dir(self, transfer):


### PR DESCRIPTION
Found this useful when using connection `Group`s with remotes configured in an SSH-config file.