### PR TITLE
default host key policy to RejectPolicy

### DIFF
--- a/fabric/connection.py
+++ b/fabric/connection.py
@@ -7,7 +7,7 @@ from decorator import decorator
 from invoke import Context
 from invoke.exceptions import ThreadException
 from paramiko.agent import AgentRequestHandler
-from paramiko.client import SSHClient, AutoAddPolicy
+from paramiko.client import SSHClient, RejectPolicy
 from paramiko.config import SSHConfig
 from paramiko.proxy import ProxyCommand
 
@@ -455,7 +455,7 @@ class Connection(Context):
 
         #: The `paramiko.client.SSHClient` instance this connection wraps.
         client = SSHClient()
-        client.set_missing_host_key_policy(AutoAddPolicy())
+        client.set_missing_host_key_policy(RejectPolicy())
         self.client = client
 
         #: A convenience handle onto the return value of

--- a/tests/connection.py
+++ b/tests/connection.py
@@ -8,7 +8,7 @@ import socket
 import time
 
 from unittest.mock import patch, Mock, call, ANY
-from paramiko.client import SSHClient, AutoAddPolicy
+from paramiko.client import SSHClient, RejectPolicy
 from paramiko import SSHConfig
 import pytest  # for mark, internal raises
 from pytest import skip, param
@@ -65,7 +65,7 @@ class Connection_:
         def defaults_to_auto_add(self):
             # TODO: change Paramiko API so this isn't a private access
             # TODO: maybe just merge with the __init__ test that is similar
-            assert isinstance(Connection("host").client._policy, AutoAddPolicy)
+            assert isinstance(Connection("host").client._policy, RejectPolicy)
 
     class init:
         "__init__"
@@ -245,7 +245,7 @@ class Connection_:
                 Connection("host")
                 Client.assert_called_once_with()
 
-            @patch("fabric.connection.AutoAddPolicy")
+            @patch("fabric.connection.RejectPolicy")
             def sets_missing_host_key_policy(self, Policy, client):
                 # TODO: should make the policy configurable early on
                 sentinel = Mock()


### PR DESCRIPTION
It's a really bad idea to silently accept new keys. It's not how SSH works, and it's not how Fabric *should* work. If we'd work like SSH, we'd *prompt* the user, but the WarningPolicy doesn't do that, it just warns, and doesn't prompt.

At the very least those policies should noisily warn the user when the host keys get changed, but that's something Paramiko must do.

An alternative to this would be WarningPolicy but I think it's too light and possibly too late: when you warn, Fabric probably has time to run the bad stuff before the operator notices and interrupts.