### PR TITLE
do not break type decorations in fabric tasks

### DIFF
--- a/fabric/tasks.py
+++ b/fabric/tasks.py
@@ -1,3 +1,5 @@
+from typing import Callable, Any
+
 import invoke
 
 from .connection import Connection
@@ -21,7 +23,7 @@ class Task(invoke.Task):
         super().__init__(*args, **kwargs)
 
 
-def task(*args, **kwargs):
+def task(*args: Any, **kwargs: Any) -> Callable:
     """
     Wraps/extends Invoke's `@task <invoke.tasks.task>` with extra kwargs.
 

--- a/fabric/tasks.pyi
+++ b/fabric/tasks.pyi
@@ -1,0 +1,10 @@
+TaskType = TypeVar("TaskType", bound=Callable[..., Any])
+
+
+@overload
+def task[TaskType: Callable[..., Any]](func: TaskType, /) -> TaskType: ...
+
+
+# Decorator with arguments
+@overload
+def task[TaskType: Callable[..., Any]](**kwargs: Any) -> Callable[[TaskType], TaskType]: ...

--- a/sites/www/changelog.rst
+++ b/sites/www/changelog.rst
@@ -13,6 +13,8 @@ Changelog
     names in this paragraph to visit their changelogs and see what you might get
     if you upgrade your dependencies.
 
+- :support:`2337 backported` Fix do not break type decorations in tasks
+
 - :release:`3.2.2 <2023-08-30>`
 - :bug:`2204` The signal handling functionality added in Fabric 2.6 caused
   unrecoverable tracebacks when invoked from inside a thread (such as the use


### PR DESCRIPTION
The invoke.task decorator has type decorations which means that decorated functions can still be typed-checked.

But it seems fabric was not converted to that yet, so you get errors like this with mypy --strict and, indeed, those functions are not checked for typing.

fabric_tpa/postgresql.py:505: error: Untyped decorator makes function "backup" untyped  [misc]

The patch reuses the type signature of invoke.task. It's not actually the exact recommendations mypy provides for that kind of stuff:

https://mypy.readthedocs.io/en/stable/generics.html#declaring-decorators

... but given the complexity of the decorator, it's not too bad.