### PR TITLE
Correct behaviour of `ProxyJump none` in ssh_config

### DIFF
--- a/fabric/connection.py
+++ b/fabric/connection.py
@@ -500,6 +500,10 @@ class Connection(Context):
     def get_gateway(self):
         # SSH config wins over Invoke-style config
         if "proxyjump" in self.ssh_config:
+            # `none` is a special value that disables the proxy jump
+            # https://man.openbsd.org/OpenBSD-current/man5/ssh_config.5#ProxyJump
+            if self.ssh_config["proxyjump"] == "none":
+                return None
             # Reverse hop1,hop2,hop3 style ProxyJump directive so we start
             # with the final (itself non-gatewayed) hop and work up to
             # the front (actual, supplied as our own gateway) hop

--- a/tests/_support/ssh_config/proxyjump.conf
+++ b/tests/_support/ssh_config/proxyjump.conf
@@ -1,2 +1,4 @@
 Host runtime
     ProxyJump jumpuser@jumphost:373
+Host nojump
+    ProxyJump none

--- a/tests/connection.py
+++ b/tests/connection.py
@@ -453,6 +453,15 @@ class Connection_:
                     # TODO: would we ever WANT a reference? can't imagine...
                     assert cxn.gateway.config is not conf
 
+                def none_value_disables_proxy_jump(self):
+                    conf = self._runtime_config(
+                        basename="proxyjump",
+                    )
+                    cxn = Connection("nojump", config=conf)
+                    assert cxn.config is conf
+                    # `none` correctly disables the proxy jump
+                    assert cxn.gateway is None
+
             class connect_timeout:
                 def wins_over_default(self):
                     assert self._runtime_cxn().connect_timeout == 15


### PR DESCRIPTION
This fixes #2354 