### PR TITLE
Bump minimum paramiko version to 3.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setuptools.setup(
     python_requres=">=3.6",
     install_requires=[
         "invoke>=2.0",
-        "paramiko>=2.4",
+        "paramiko>=3.2",
         "decorator>=5",
         "deprecated>=1.2",
     ],


### PR DESCRIPTION
## Summary

Fixes #2329.

`fabric.auth` imports from `paramiko.auth_strategy`, which was added in paramiko 3.2.0. The previous constraint (`>=2.4`) allowed installing paramiko versions that lack this module, causing `ModuleNotFoundError` at import time.

## Change

`setup.py`: `paramiko>=2.4` → `paramiko>=3.2`