### PR TITLE
Fix close() not cleaning up transport threads after auth failure

### DIFF
--- a/fabric/connection.py
+++ b/fabric/connection.py
@@ -723,9 +723,12 @@ class Connection(Context):
             self._sftp = None
 
         if self.is_connected:
-            self.client.close()
             if self.forward_agent and self._agent_handler is not None:
                 self._agent_handler.close()
+
+        # Always close the client to clean up transport threads, even
+        # after a failed authentication where is_connected is False.
+        self.client.close()
 
     def __enter__(self):
         return self

--- a/tests/connection.py
+++ b/tests/connection.py
@@ -989,12 +989,12 @@ class Connection_:
             # to run multiple handlers at once
             Handler.return_value.close.assert_called_once_with()
 
-        def short_circuits_if_not_connected(self, client):
+        def cleans_up_transport_even_if_not_connected(self, client):
             c = Connection("host")
-            # Won't trigger close() on client because it'll already think it's
-            # closed (due to no .transport & the behavior of .is_connected)
+            # Always calls client.close() to clean up transport threads
+            # even after a failed authentication where is_connected is False.
             c.close()
-            assert not client.close.called
+            client.close.assert_called_once_with()
 
         def class_works_as_a_closing_contextmanager(self, client):
             with Connection("host") as c:


### PR DESCRIPTION
## Summary

Fixes #2259.

When SSH authentication fails, `is_connected` returns `False` because the transport is not active. But paramiko's transport threads are still running (5 threads per failed attempt). `close()` previously only called `client.close()` when `is_connected` was `True`, leaking threads.

The fix: always call `self.client.close()` regardless of connection state. `paramiko.SSHClient.close()` is safe to call on clients that never connected or failed to authenticate — it checks internally.

## Test plan

- [x] Updated `short_circuits_if_not_connected` test to verify `client.close()` IS called even when not connected
- [x] All 7 close tests pass
- [x] 140 connection tests pass (17 pre-existing failures in `from_v1` and `shell` tests)