### PR TITLE
fix: bump minimum paramiko version to 3.2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setuptools.setup(
     python_requres=">=3.6",
     install_requires=[
         "invoke>=2.0",
-        "paramiko>=2.4",
+        "paramiko>=3.2.0",
         "decorator>=5",
         "deprecated>=1.2",
     ],


### PR DESCRIPTION
## Summary
Fixes #2329.
**Root cause:** Fabric imports `paramiko.auth_strategy` which was added in paramiko 3.2.0, but the minimum version constraint allowed paramiko >= 2.4.0, causing `ModuleNotFoundError` for users with older paramiko versions.
**Fix:** Bumped the minimum paramiko version to >= 3.2.0.
## Changes
- Updated paramiko version constraint in setup.py
## Testing
- Verified fix prevents ModuleNotFoundError with paramiko >= 3.2.0
- Change is minimal (version constraint update)

Made with [Cursor](https://cursor.com)