### PR TITLE
bump minimum paramiko version to 3.2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setuptools.setup(
     python_requres=">=3.6",
     install_requires=[
         "invoke >= 3.0",
-        "paramiko>=2.4",
+        "paramiko>=3.2.0",
         "decorator>=5",
         "deprecated>=1.2",
     ],


### PR DESCRIPTION
## Summary

fabric.auth imports classes from `paramiko.auth_strategy` (added in paramiko 3.2.0), but setup.py still lists `paramiko>=2.4` as the minimum. This causes a `ModuleNotFoundError` for users with older paramiko installs (e.g. 3.1.0).

Fixes #2329

## Changes

- Bump minimum paramiko version from `>=2.4` to `>=3.2.0` in `setup.py`

## Verification

The fix aligns the declared dependency with the actual import requirement.