### PR TITLE
Tolerate malformed or encrypted identity files when scanning SSH keys

### DIFF
--- a/fabric/auth.py
+++ b/fabric/auth.py
@@ -9,8 +9,34 @@ from paramiko.auth_strategy import (
     InMemoryPrivateKey,
     OnDiskPrivateKey,
 )
+from paramiko.pkey import UnknownKeyType
+from paramiko.ssh_exception import (
+    PasswordRequiredException,
+    SSHException,
+)
 
-from .util import win32
+from .util import win32, debug
+
+# Errors we treat as "skip this identity file" when scanning identity paths.
+# PKey.from_path can raise:
+#   FileNotFoundError       — path doesn't exist
+#   OSError                 — permission denied, is-a-directory, etc.
+#   ValueError              — malformed PEM bytes / wrong password
+#   UnknownKeyType          — backend doesn't recognize the key type
+#   PasswordRequiredException — encrypted key, no password supplied
+#   SSHException            — other paramiko parse/load failures
+# Together these cover every "this file isn't a usable private key" case, so
+# we silently skip rather than crash an entire connection attempt because one
+# of the configured identities (or one of the default ~/.ssh/id_* files) is
+# bad. Users who care can enable fabric debug logging to see the cause.
+_SKIP_KEY_ERRORS = (
+    FileNotFoundError,
+    OSError,
+    ValueError,
+    UnknownKeyType,
+    PasswordRequiredException,
+    SSHException,
+)
 
 
 class OpenSSHAuthStrategy(AuthStrategy):
@@ -99,7 +125,8 @@ class OpenSSHAuthStrategy(AuthStrategy):
         for path in self.config.authentication.identities:
             try:
                 key = PKey.from_path(path)
-            except FileNotFoundError:
+            except _SKIP_KEY_ERRORS as exc:
+                debug(f"skipping identity {path!r}: {exc}")
                 continue
             source = OnDiskPrivateKey(
                 username=self.username,
@@ -118,7 +145,8 @@ class OpenSSHAuthStrategy(AuthStrategy):
         for path in self.ssh_config.get("identityfile", []):
             try:
                 key = PKey.from_path(path)
-            except FileNotFoundError:
+            except _SKIP_KEY_ERRORS as exc:
+                debug(f"skipping ssh_config IdentityFile {path!r}: {exc}")
                 continue
             source = OnDiskPrivateKey(
                 username=self.username,
@@ -136,7 +164,8 @@ class OpenSSHAuthStrategy(AuthStrategy):
                 path = user_ssh / f"id_{type_}"
                 try:
                     key = PKey.from_path(path)
-                except FileNotFoundError:
+                except _SKIP_KEY_ERRORS as exc:
+                    debug(f"skipping default key {path!r}: {exc}")
                     continue
                 source = OnDiskPrivateKey(
                     username=self.username,

--- a/tests/auth.py
+++ b/tests/auth.py
@@ -126,6 +126,29 @@ class OpenSSHAuthStrategy_:
                 assert keys[0].pkey is key
                 assert keys[0].path == "ed25519.key"
 
+            def silently_skips_malformed_and_encrypted_keys(self, fake):
+                from paramiko.pkey import UnknownKeyType
+                from paramiko.ssh_exception import PasswordRequiredException, SSHException
+
+                key = Mock()
+                # Order matters: rsa.key raises ValueError (bad PEM),
+                # ed25519.key raises UnknownKeyType, ecdsa.key raises
+                # PasswordRequiredException, and the second rsa is a good key.
+                fake.PKey.from_path.side_effect = [
+                    ValueError("bad PEM"),
+                    UnknownKeyType(key_bytes=b"junk", key_type=str),
+                    PasswordRequiredException(),
+                    SSHException("parse failure"),
+                    key,
+                ]
+                strat = _strategy(
+                    py_keys=["rsa1.key", "ed25519.key", "ecdsa.key", "rsa2.key", "good.key"]
+                )
+                keys = list(strat.get_pubkeys())
+                assert len(keys) == 1
+                assert keys[0].pkey is key
+                assert keys[0].path == "good.key"
+
         class ssh_config:
             def loads_identityfile_key(self, fake):
                 strat = _strategy(ssh_keys=["rsa.key"])
@@ -146,6 +169,29 @@ class OpenSSHAuthStrategy_:
                 assert len(keys) == 1
                 assert keys[0].pkey is key
                 assert keys[0].path == "ed25519.key"
+
+            def silently_skips_malformed_and_encrypted_keys(self, fake):
+                from paramiko.pkey import UnknownKeyType
+                from paramiko.ssh_exception import PasswordRequiredException, SSHException
+
+                key = Mock()
+                # Order matters: rsa.key raises ValueError (bad PEM),
+                # ed25519.key raises UnknownKeyType, ecdsa.key raises
+                # PasswordRequiredException, and the second rsa is a good key.
+                fake.PKey.from_path.side_effect = [
+                    ValueError("bad PEM"),
+                    UnknownKeyType(key_bytes=b"junk", key_type=str),
+                    PasswordRequiredException(),
+                    SSHException("parse failure"),
+                    key,
+                ]
+                strat = _strategy(
+                    ssh_keys=["rsa1.key", "ed25519.key", "ecdsa.key", "rsa2.key", "good.key"]
+                )
+                keys = list(strat.get_pubkeys())
+                assert len(keys) == 1
+                assert keys[0].pkey is key
+                assert keys[0].path == "good.key"
 
         class implicit_user_home_locations:
             def loads_all_four_known_key_types(self, fake):
@@ -180,6 +226,26 @@ class OpenSSHAuthStrategy_:
                         "id_dsa",
                     ]
                 ]
+
+            def silently_skips_malformed_and_encrypted_keys(self, fake):
+                from paramiko.pkey import UnknownKeyType
+                from paramiko.ssh_exception import PasswordRequiredException, SSHException
+
+                key = Mock()
+                # Order matters: rsa.key raises ValueError (bad PEM),
+                # ed25519.key raises UnknownKeyType, ecdsa.key raises
+                # PasswordRequiredException, and the second rsa is a good key.
+                fake.PKey.from_path.side_effect = [
+                    ValueError("bad PEM"),
+                    UnknownKeyType(key_bytes=b"junk", key_type=str),
+                    PasswordRequiredException(),
+                    key,
+                ]
+                strat = _strategy()
+                keys = list(strat.get_pubkeys())
+                assert len(keys) == 1
+                assert keys[0].pkey is key
+                assert keys[0].path is not None
 
             def does_not_load_if_config_based_keys_given(self, fake):
                 strat = _strategy(py_keys=["rsa.key"])


### PR DESCRIPTION
## Summary

`OpenSSHAuthStrategy.get_pubkeys` caught only `FileNotFoundError` around `PKey.from_path`, but `PKey.from_path` can raise several other classes for files that exist yet are not usable private keys:

- `ValueError` — bad PEM bytes or wrong password
- `OSError` — permission denied or non-file at the path
- `UnknownKeyType` — cryptography backend doesn't recognize the key
- `PasswordRequiredException` — encrypted key with no password supplied
- `SSHException` — other paramiko parse/load failures

A user with one such file in their identities list, ssh_config IdentityFile, or `~/.ssh/id_*` default locations would crash an entire connection attempt with an unhandled traceback instead of just skipping the bad file the way OpenSSH does.

## Fix

Introduce `_SKIP_KEY_ERRORS` covering all of these and emit a fabric debug log line naming the path and the underlying exception so users who care can still see why a key was dropped.

## Tests

Three new tests, one per source:
- `tests/auth.py::OpenSSHAuthStrategy_::get_pubkeys::fabric_config::silently_skips_malformed_and_encrypted_keys`
- `tests/auth.py::OpenSSHAuthStrategy_::get_pubkeys::ssh_config::silently_skips_malformed_and_encrypted_keys`
- `tests/auth.py::OpenSSHAuthStrategy_::get_pubkeys::implicit_user_home_locations::silently_skips_malformed_and_encrypted_keys`

Each exercises `ValueError`, `UnknownKeyType`, and `PasswordRequiredException` / `SSHException` in sequence and asserts the strategy still yields the one good key.