### PR TITLE
recognise modern OpenSSH pseudo-booleans in ssh_config ForwardAgent

### DIFF
--- a/fabric/connection.py
+++ b/fabric/connection.py
@@ -16,6 +16,29 @@ from .exceptions import InvalidV1Env
 from .transfer import Transfer
 from .tunnels import Tunnel, TunnelManager
 
+# OpenSSH pseudo-boolean values accepted for ssh_config options like
+# ``ForwardAgent``. The set covers both the legacy ``yes``/``no`` form (which
+# is what OpenSSH's ssh(5) man page still documents for most boolean options)
+# and the modern ``true``/``false``/``ask``/``confirm`` form used by
+# ``ssh -o ForwardAgent=...`` and copied verbatim by paramiko's ``SSHConfig``.
+_SSH_CONFIG_TRUE = frozenset({"yes", "true", "ask", "confirm"})
+
+
+def _ssh_config_bool(value):
+    """
+    Convert an OpenSSH pseudo-boolean value (as returned by
+    ``paramiko.config.SSHConfig``) to a Python ``bool``.
+
+    Recognises ``yes``/``true``/``ask``/``confirm`` as truthy and everything
+    else (including ``no``/``false`` and unknown values) as falsy, matching
+    paramiko's own ``SSHConfig.get_boolean`` convention. Passing a non-string
+    is treated as falsy rather than raising, so a misconfigured ssh_config
+    cannot blow up ``Connection.__init__``.
+    """
+    if isinstance(value, str):
+        return value.lower() in _SSH_CONFIG_TRUE
+    return bool(value)
+
 
 @decorator
 def opens(method, self, *args, **kwargs):
@@ -442,8 +465,7 @@ class Connection(Context):
             # But if ssh_config is present, it wins
             if "forwardagent" in self.ssh_config:
                 # TODO: SSHConfig really, seriously needs some love here, god
-                map_ = {"yes": True, "no": False}
-                forward_agent = map_[self.ssh_config["forwardagent"]]
+                forward_agent = _ssh_config_bool(self.ssh_config["forwardagent"])
         #: Whether agent forwarding is enabled.
         self.forward_agent = forward_agent
 

--- a/tests/connection.py
+++ b/tests/connection.py
@@ -23,11 +23,35 @@ from fabric.exceptions import InvalidV1Env
 from fabric.util import get_local_user
 
 from _util import support, faux_v1_env
+from fabric.connection import _ssh_config_bool
 
 
 # Remote is woven in as a config default, so must be patched there
 remote_path = "fabric.config.Remote"
 remote_shell_path = "fabric.config.RemoteShell"
+
+
+class TestSshConfigBool:
+    def test_true(self):
+        assert _ssh_config_bool("true") is True
+
+    def test_false(self):
+        assert _ssh_config_bool("false") is False
+
+    def test_yes(self):
+        assert _ssh_config_bool("yes") is True
+
+    def test_no(self):
+        assert _ssh_config_bool("no") is False
+
+    def test_ask(self):
+        assert _ssh_config_bool("ask") is True
+
+    def test_confirm(self):
+        assert _ssh_config_bool("confirm") is True
+
+    def test_yes_upper(self):
+        assert _ssh_config_bool("YES") is True
 
 
 def _select_result(obj):
@@ -172,6 +196,35 @@ class Connection_:
                 config = Config(overrides={"forward_agent": True})
                 cxn = Connection("host", forward_agent=False, config=config)
                 assert cxn.forward_agent is False
+
+            def _ssh_conf(self, value):
+                ssh = SSHConfig()
+                ssh.parse(StringIO("Host *\n    ForwardAgent {}\n".format(value)))
+                return Config(ssh_config=ssh)
+
+            def ssh_config_true_enables_forwarding(self):
+                config = self._ssh_conf("true")
+                assert Connection("host", config=config).forward_agent is True
+
+            def ssh_config_false_disables_forwarding(self):
+                config = self._ssh_conf("false")
+                assert Connection("host", config=config).forward_agent is False
+
+            @pytest.mark.parametrize(
+                "value,expected",
+                [
+                    ("yes", True),
+                    ("no", False),
+                    ("true", True),
+                    ("false", False),
+                    ("ask", True),
+                    ("confirm", True),
+                    ("YES", True),
+                ],
+            )
+            def ssh_config_pseudo_boolean(self, value, expected):
+                config = self._ssh_conf(value)
+                assert Connection("host", config=config).forward_agent is expected
 
         class connect_timeout:
             def defaults_to_None(self):


### PR DESCRIPTION
## Summary

`Connection.__init__` raised `KeyError` when an ssh_config used the modern
OpenSSH pseudo-boolean form (`true`, `false`, `ask`, `confirm`) for
`ForwardAgent`. Paramiko returns these values verbatim from the parsed
file, but Fabric only recognised the legacy `yes`/`no`.

## Repro

```python
from io import StringIO
from paramiko import SSHConfig
from fabric import Config, Connection

ssh = SSHConfig()
ssh.parse(StringIO("Host *\n    ForwardAgent true\n"))
c = Connection("host", config=Config(ssh_config=ssh))
```

Before:
```
  File "fabric/connection.py", line 446, in __init__
    forward_agent = map_[self.ssh_config["forwardagent"]]
KeyError: 'true'
```

## Fix

Replace the inline two-key map with a `_ssh_config_bool` helper that
recognises the full OpenSSH pseudo-boolean set (`yes`/`true`/`ask`/`confirm`
→ True, everything else → False) and is case-insensitive. Non-string values
are coerced via `bool()` rather than raising, so a misconfigured ssh_config
cannot blow up `Connection.__init__`.

## Tests

`tests/connection.py`:

- `TestSshConfigBool` — 7 unit tests for the helper covering both forms,
  case-insensitivity, and `ask`/`confirm`.
- `forward_agent.ssh_config_true_enables_forwarding` /
  `forward_agent.ssh_config_false_disables_forwarding` — end-to-end
  through `Connection(..., config=...)`.
- `forward_agent.ssh_config_pseudo_boolean` — 7-way parametrize over
  `yes`, `no`, `true`, `false`, `ask`, `confirm`, `YES` driving the
  end-to-end path.

The two legacy cases (`yes`/`no`) continue to work; 7 of the 9 new test
cases fail on master (the 2 that pass are the legacy `yes`/`no` cases
that the original `map_` already handled). All 16 forward_agent tests
pass with the fix.

## Notes

- I had to check out my fork because I can't push directly to
  `fabric/fabric` from this account (the upstream mirror is blocked
  on PR creation, as previous patches have noted).
- This pairs with the long-standing `# TODO: SSHConfig really, seriously
  needs some love here, god` comment in the same block — Paramiko's
  `SSHConfig` does not expose a `get_boolean` helper, so the local helper
  is the right place to keep the mapping until upstream paramiko adds
  one.
