### PR TITLE
Fix typos in comments, docstrings, and docs

### DIFF
--- a/fabric/executor.py
+++ b/fabric/executor.py
@@ -34,10 +34,10 @@ class Executor(invoke.Executor):
         is to simply assume that strings are 'host' kwargs).
 
         :param hosts:
-            Potentially heterogenous list of host connection values, as per the
+            Potentially heterogeneous list of host connection values, as per the
             ``hosts`` param to `.task`.
 
-        :returns: Homogenous list of Connection init kwarg dicts.
+        :returns: Homogeneous list of Connection init kwarg dicts.
         """
         dicts = []
         for value in hosts or []:

--- a/fabric/group.py
+++ b/fabric/group.py
@@ -261,7 +261,7 @@ class ThreadingGroup(Group):
             # TODO: io-sleep? shouldn't matter if all threads are now joined
             cxn, result = queue.get(block=False)
             # TODO: outstanding musings about how exactly aggregate results
-            # ought to ideally operate...heterogenous obj like this, multiple
+            # ought to ideally operate...heterogeneous obj like this, multiple
             # objs, ??
             results[cxn] = result
         # Get exceptions from the threads themselves.

--- a/fabric/tasks.py
+++ b/fabric/tasks.py
@@ -54,7 +54,7 @@ def task(*args, **kwargs):
           params like auth info, etc).
 
         These two value types *may* be mixed together in the same list, though
-        we recommend that you keep things homogenous when possible, to avoid
+        we recommend that you keep things homogeneous when possible, to avoid
         confusion when debugging.
 
         .. note::

--- a/fabric/tunnels.py
+++ b/fabric/tunnels.py
@@ -87,7 +87,7 @@ class TunnelManager(ExceptionHandlingThread):
             tunnels.append(tunnel)
 
         exceptions = []
-        # Propogate shutdown signal to all tunnels & wait for closure
+        # Propagate shutdown signal to all tunnels & wait for closure
         # TODO: would be nice to have some output or at least logging here,
         # especially for "sets up a handful of tunnels" use cases like
         # forwarding nontrivial HTTP traffic.

--- a/sites/docs/concepts/configuration.rst
+++ b/sites/docs/concepts/configuration.rst
@@ -219,7 +219,7 @@ Proxying
 
   - Nested-style ``ProxyJump``, i.e. ``user1@hop1.host,user2@hop2.host,...``,
     will result in an appropriate series of nested ``gateway`` values under the
-    hood - as if the user had manually specified ``Connecton(...,
+    hood - as if the user had manually specified ``Connection(...,
     gateway=Connection('user1@hop1.host',
     gateway=Connection('user2@hop2.host', gateway=...)))``.
 


### PR DESCRIPTION
Fix several spelling errors found in comments, docstrings, and documentation:

- `heterogenous` -> `heterogeneous` (fabric/executor.py, fabric/group.py)
- `Homogenous` / `homogenous` -> `Homogeneous` / `homogeneous` (fabric/executor.py, fabric/tasks.py)
- `Propogate` -> `Propagate` (fabric/tunnels.py)
- `Connecton` -> `Connection` (sites/docs/concepts/configuration.rst)

All changes are in comments, docstrings, or documentation — no functional code affected.