### PR TITLE
Escape env vars in inline_env shell prefix to prevent command injection

### DIFF
--- a/fabric/runners.py
+++ b/fabric/runners.py
@@ -1,3 +1,4 @@
+import shlex
 import signal
 import threading
 
@@ -60,12 +61,13 @@ class Remote(Runner):
             # honor it even when prefixing? That would depart from OpenSSH
             # somewhat (albeit as a "what we can do that it cannot" feature...)
             if self.inline_env:
-                # TODO: escaping, if we can find a FOOLPROOF THIRD PARTY METHOD
-                # for doing so!
                 # TODO: switch to using a higher-level generic command
                 # prefixing functionality, when implemented.
                 parameters = " ".join(
-                    ["{}={}".format(k, v) for k, v in sorted(env.items())]
+                    [
+                        "{}={}".format(shlex.quote(k), shlex.quote(v))
+                        for k, v in sorted(env.items())
+                    ]
                 )
                 # NOTE: we can assume 'export' and '&&' relatively safely, as
                 # sshd always brings some shell into play, even if it's just

--- a/tests/runners.py
+++ b/tests/runners.py
@@ -189,6 +189,17 @@ class Remote_:
             r.run(CMD, env={"PATH": "/opt/bin", "DEBUG": "1"})
             assert not chan.update_environment.called
 
+        def quotes_env_values_when_inline_env_is_True(self, remote):
+            # https://github.com/fabric/fabric/issues/2364 -- env values must
+            # be shell-escaped, otherwise crafted values can execute arbitrary
+            # commands (e.g. "X=a; echo INJECTED #").
+            chan = remote.expect(
+                cmd="export X='a; echo INJECTED #' && {}".format(CMD)
+            )
+            r = Remote(context=_Connection("host"), inline_env=True)
+            r.run(CMD, env={"X": "a; echo INJECTED #"})
+            assert not chan.update_environment.called
+
     def send_start_message_sends_exec_command(self):
         runner = Remote(context=None)
         runner.channel = Mock()


### PR DESCRIPTION
## Summary

Fixes #2364 — env values passed to `run()` (via `env=`) were concatenated directly into the `export ... && command` shell string without escaping. A crafted value like `"X": "a; echo INJECTED #"` executed arbitrary commands on the remote host.

## Fix

Quote both keys and values with `shlex.quote()` when building the inline `export` prefix. `shlex.quote` leaves already-safe values (e.g. `DEBUG`, `1`, `/opt/bin`) untouched, so existing behavior for normal usage is unchanged — only shell-special characters get quoted.

Also removes the now-stale `TODO: escaping, if we can find a FOOLPROOF THIRD PARTY METHOD` comment, since `shlex.quote` is that method (it's POSIX-shell-safe and part of the stdlib).

## Reproduction (before)

```python
c.run("echo hello", env={"X": "a; echo INJECTED #"})
# Executes: export X=a; echo INJECTED # && echo hello
```

## After

```
export X='a; echo INJECTED #' && echo hello
```

## Tests

- New `quotes_env_values_when_inline_env_is_True` regression test asserting the escaped command is sent.
- Existing `uses_export_prefixing_when_inline_env_is_True` still passes (safe values unchanged).
- Full suite: identical failures vs. main (45 pre-existing environment-dependent failures, 353 passed vs. 352 on main — my test is the +1).
- flake8 clean.

🤖 Generated with Codebuff
