### PR TITLE
Fix ambiguous run/Connection wording in getting-started docs

### DIFF
--- a/sites/docs/getting-started.rst
+++ b/sites/docs/getting-started.rst
@@ -83,7 +83,7 @@ example:
     'web1'
 
 Meet `.Connection`, which represents an SSH connection and provides the core of
-Fabric's API, such as `~.Connection.run`. `.Connection` objects need at least a
+Fabric's API, such as the `~.Connection.run` method. `.Connection` objects need at least a
 hostname to be created successfully, and may be further parameterized by
 username and/or port number. You can give these explicitly via args/kwargs::
 


### PR DESCRIPTION
## Problem

In the "Getting started" docs, `run` and `Connection` appeared back-to-back,
both bolded, making it look like `run` was an attribute of `Connection`
rather than the end of one sentence and the start of the next.

## Fix

Added "method" after `run` in that one sentence, so it reads as `run` method
instead of a bare bolded term next to `Connection`.

## Why not a broader change

`run` is used elsewhere on the page both as a plain verb and as the bolded
method name, that's fine, since only this one instance has the two bolded
terms adjacent. Left everything else on the page untouched.

Closes #2349