### PR TITLE
Accept path-like local destinations in get()

### DIFF
--- a/fabric/transfer.py
+++ b/fabric/transfer.py
@@ -6,6 +6,7 @@ import os
 import posixpath
 import stat
 
+from os import fspath
 from pathlib import Path
 
 from .util import debug  # TODO: actual logging! LOL
@@ -96,6 +97,10 @@ class Transfer:
             **If a file-like object is given**, the contents of the remote file
             are simply written into it.
 
+            **If a path-like object is given** (such as `pathlib.Path`), it is
+            converted with `os.fspath` and processed like a string, including
+            interpolation. Its ``__fspath__`` method must return a string.
+
         :param bool preserve_mode:
             Whether to `os.chmod` the local file so it matches the remote
             file's mode (default: ``True``).
@@ -108,6 +113,8 @@ class Transfer:
             attributes.
         .. versionchanged:: 2.6
             Create missing ``local`` directories automatically.
+        .. versionchanged:: 4.0
+            Accept string-returning path-like objects for ``local``.
         """
         # TODO: how does this API change if we want to implement
         # remote-to-remote file transfer? (Is that even realistic?)
@@ -134,7 +141,7 @@ class Transfer:
         # Path-driven local downloads need interpolation, abspath'ing &
         # directory creation
         if not is_file_like:
-            local = local.format(
+            local = fspath(local).format(
                 host=self.connection.host,
                 user=self.connection.user,
                 port=self.connection.port,
@@ -193,6 +200,9 @@ class Transfer:
 
             **If a string is given**, it should be a path to a local (regular)
             file (not a directory).
+
+            String-returning path-like objects (such as `pathlib.Path`) are
+            also accepted and processed like string paths.
 
             .. note::
                 When dealing with nonexistent file paths, normal Python file

--- a/sites/www/changelog.rst
+++ b/sites/www/changelog.rst
@@ -13,6 +13,9 @@ Changelog
     names in this paragraph to visit their changelogs and see what you might get
     if you upgrade your dependencies.
 
+- :feature:`2326` Accept string-returning path-like objects, such as
+  `pathlib.Path`, as local download paths in `~fabric.transfer.Transfer.get`.
+  Thanks to sandeep-gh for the report and Jerry-val for the patch.
 - :release:`3.2.3 <2026-04-05>`
 - :support:`- backported` Tweak packaging metadata to reflect that Invoke 3.0
   has a backwards incompatible API change that we can't use yet.

--- a/tests/transfer.py
+++ b/tests/transfer.py
@@ -1,4 +1,5 @@
 from io import StringIO
+from pathlib import Path
 
 from unittest.mock import Mock, call, patch
 from pytest_relaxed import raises
@@ -58,6 +59,31 @@ class Transfer_:
                     remotepath="/remote/path1", localpath="/local/path2"
                 )
 
+            def accepts_local_pathlib_path(self, sftp_objs):
+                transfer, client = sftp_objs
+                local = Path("downloads/file.txt")
+                result = transfer.get("file", local=local)
+                client.get.assert_called_with(
+                    remotepath="/remote/file",
+                    localpath="/local/downloads/file.txt",
+                )
+                assert result.local == "/local/downloads/file.txt"
+                assert result.orig_local is local
+
+            def accepts_local_pathlike_object(self, sftp_objs):
+                class LocalPath:
+                    def __fspath__(self):
+                        return "downloads/file.txt"
+
+                transfer, client = sftp_objs
+                local = LocalPath()
+                result = transfer.get("file", local=local)
+                client.get.assert_called_with(
+                    remotepath="/remote/file",
+                    localpath="/local/downloads/file.txt",
+                )
+                assert result.orig_local is local
+
             def returns_rich_Result_object(self, sftp_objs):
                 transfer, client = sftp_objs
                 cxn = Connection("host")
@@ -90,6 +116,12 @@ class Transfer_:
                 transfer.get("")
 
         class local_arg_interpolation:
+            def pathlib_path(self, transfer):
+                local = Path("{host}/{basename}")
+                result = transfer.get("parent/file.txt", local=local)
+                assert result.local == "/local/host/file.txt"
+                assert result.orig_local is local
+
             def connection_params(self, transfer):
                 result = transfer.get("somefile", "{user}@{host}-{port}")
                 expected = "/local/{}@host-22".format(transfer.connection.user)
@@ -179,6 +211,17 @@ class Transfer_:
 
     class put:
         class basics:
+            def accepts_local_pathlib_path(self, sftp_objs):
+                transfer, client = sftp_objs
+                local = Path("uploads/file.txt")
+                result = transfer.put(local)
+                client.put.assert_called_with(
+                    localpath="/local/uploads/file.txt",
+                    remotepath="/remote/file.txt",
+                )
+                assert result.local == "/local/uploads/file.txt"
+                assert result.orig_local is local
+
             def accepts_single_local_path_posarg(self, sftp_objs):
                 transfer, client = sftp_objs
                 transfer.put("file")


### PR DESCRIPTION
Fixes #2326.

`Connection.get("file.txt", local=Path("downloads/file.txt"))` currently raises `AttributeError` because the local argument is passed directly to `str.format`. Convert non-file-like local arguments with `os.fspath` before the existing interpolation and path handling. The original argument remains available in `Result.orig_local`.

Add regression coverage for `pathlib.Path`, custom string-returning `__fspath__` objects, and interpolation in path objects. Also document and test the existing support for local `Path` objects in `put()`. Include API documentation and a changelog entry.

I checked the issue discussion, current main, and related open/closed PRs before implementing this. The existing path/interpolation changes in #2253, #2254, #2333 and #2372 do not handle this case.

Validation:

- Before the fix: the three new download tests fail with the reported `AttributeError`; the upload compatibility test passes.
- `python -m pytest tests/transfer.py -q`: 41 passed.
- `python -m pytest -q`: 398 passed, 7 skipped (Python 3.12.14; existing deprecation warnings).
- Flake8 4.0.1 over `fabric` and `tests`: passed using Python 3.9.6, since this pinned Flake8 version's plugin loader is incompatible with Python 3.12.
- `python -m black --check --diff --line-length 79 fabric/transfer.py tests/transfer.py`: passed.
- `git diff --check`: passed.

The tests use the project's mocked SFTP fixtures; a live SSH/SFTP server was not used.